### PR TITLE
add uglify-mangle-only to bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The fast, future-friendly minifier. [Try before you buy at butternut.now.sh](htt
 
 ## Why?
 
-Butternut is significantly faster than other JavaScript minifiers, and works with the latest version of JavaScript (ES2015, aka ES6, and beyond). It's typically around 4x faster than [UglifyJS](https://github.com/mishoo/UglifyJS2) and 10-15x faster than [Babili](https://github.com/babel/babili).
+Butternut is significantly faster than other JavaScript minifiers, and works with the latest version of JavaScript (ES2015, aka ES6, and beyond). It's typically around 3x faster than [UglifyJS](https://github.com/mishoo/UglifyJS2) with default minify options, and 10-15x faster than [Babili](https://github.com/babel/babili).
 
 The compression is better than Babili and [closure-compiler-js](https://github.com/google/closure-compiler-js) (in standard compilation mode — you can get better results with Closure in advanced mode, but only by writing your code in a very particular way). It's *almost* as good as Uglify in its current version.
 

--- a/test/bench/index.js
+++ b/test/bench/index.js
@@ -30,6 +30,7 @@ const libs = [
 	'butternut',
 	'closure',
 	'uglify',
+	'uglify-mangle-only',
 	'uglify-es'
 ];
 
@@ -48,7 +49,7 @@ function printResult (results, name, sourcemap) {
 
 	const time = prettyMs(sourcemap ? r.sourcemap : r.nosourcemap);
 	console.log(
-		`  ${indicator} ${rightPad(name, 10)}: ${leftPad(prettyBytes(r.min), 8)} / ${leftPad(prettyBytes(r.zip), 8)} in ${time}`
+		`  ${indicator} ${rightPad(name, 19)}: ${leftPad(prettyBytes(r.min), 8)} / ${leftPad(prettyBytes(r.zip), 8)} in ${time}`
 	);
 }
 

--- a/test/bench/uglify-mangle-only-bench.js
+++ b/test/bench/uglify-mangle-only-bench.js
@@ -1,0 +1,14 @@
+const UglifyJS = require('uglify-js');
+
+exports.minify = (input, sourcemap) => {
+	const opts = { mangle: true, compress: false };
+
+	if ( sourcemap ) {
+		opts.sourceMap = {
+			filename: "out.js",
+			url: "out.js.map"
+		};
+	}
+
+	return UglifyJS.minify({ 'input.js': input }, opts);
+};


### PR DESCRIPTION
Add `uglify` with only the `mangle` option enabled in the benchmark. Its speed and gzip output size is comparable to `butternut` on average.

Timings below with this PR using node 6.9.0 and Butternut version 0.3.5:
```
$ node test/bench/index.js -- cold

acorn.js (132 kB) without sourcemap:
  ✓ babili             :  74.2 kB /  21.6 kB in 2.3s
  ✓ butternut          :  72.7 kB /  21.1 kB in 277ms
  ✓ closure            :  72.8 kB /  21.2 kB in 7.9s
  ✓ uglify             :  65.9 kB /  21.5 kB in 879ms
  ✓ uglify-mangle-only :  68.3 kB /  21.6 kB in 223ms
  ✓ uglify-es          :  65.9 kB /  21.5 kB in 1s
acorn.js (132 kB) with sourcemap:
  ✓ babili             :  74.2 kB /  21.6 kB in 1.9s
  ✓ butternut          :  72.7 kB /  21.1 kB in 273ms
  ✓ closure            :  72.8 kB /  21.2 kB in 5.3s
  ✓ uglify             :  65.9 kB /  21.5 kB in 658ms
  ✓ uglify-mangle-only :  68.3 kB /  21.6 kB in 228ms
  ✓ uglify-es          :  65.9 kB /  21.5 kB in 761ms
async.js (183 kB) without sourcemap:
  ✓ babili             :  25.5 kB /  8.98 kB in 1.2s
  ✓ butternut          :  24.2 kB /  8.64 kB in 149ms
  ✓ closure            :  24.6 kB /  8.72 kB in 3.9s
  ✓ uglify             :  23.3 kB /  8.17 kB in 444ms
  ✓ uglify-mangle-only :  25.2 kB /  8.67 kB in 108ms
  ✓ uglify-es          :  23.3 kB /  8.17 kB in 542ms
async.js (183 kB) with sourcemap:
  ✓ babili             :  25.5 kB /  8.98 kB in 1.1s
  ✓ butternut          :  24.2 kB /  8.64 kB in 166ms
  ✓ closure            :  24.6 kB /  8.72 kB in 3.2s
  ✓ uglify             :  23.3 kB /   8.2 kB in 359ms
  ✓ uglify-mangle-only :  25.3 kB /   8.7 kB in 112ms
  ✓ uglify-es          :  23.3 kB /   8.2 kB in 455ms
backbone.js (72.2 kB) without sourcemap:
  ✓ babili             :  22.7 kB /  7.73 kB in 764ms
  ✓ butternut          :  22.7 kB /  7.58 kB in 81ms
  ✓ closure            :  24.8 kB /  8.29 kB in 2.7s
  ✓ uglify             :  22.4 kB /  7.44 kB in 266ms
  ✓ uglify-mangle-only :  23.3 kB /  7.53 kB in 74ms
  ✓ uglify-es          :  22.4 kB /  7.44 kB in 326ms
backbone.js (72.2 kB) with sourcemap:
  ✓ babili             :  22.7 kB /  7.73 kB in 790ms
  ✓ butternut          :  22.7 kB /  7.58 kB in 96ms
  ✓ closure            :  24.8 kB /  8.29 kB in 2.4s
  ✓ uglify             :  22.4 kB /  7.47 kB in 221ms
  ✓ uglify-mangle-only :  23.3 kB /  7.55 kB in 91ms
  ✓ uglify-es          :  22.4 kB /  7.47 kB in 279ms
d3.js (459 kB) without sourcemap:
  ✓ babili             :   240 kB /  78.7 kB in 19.4s
  ✓ butternut          :   220 kB /  73.7 kB in 979ms
  ✓ closure            :   218 kB /  75.7 kB in 21s
  ✓ uglify             :   216 kB /    73 kB in 3s
  ✓ uglify-mangle-only :   223 kB /  73.5 kB in 1.3s
  ✓ uglify-es          :   216 kB /    73 kB in 3.5s
d3.js (459 kB) with sourcemap:
  ✓ babili             :   240 kB /  78.7 kB in 18.6s
  ✓ butternut          :   220 kB /  73.7 kB in 1.3s
  ✓ closure            :   218 kB /  75.7 kB in 20.5s
  ✓ uglify             :   216 kB /  73.1 kB in 2.9s
  ✓ uglify-mangle-only :   223 kB /  73.5 kB in 1.1s
  ✓ uglify-es          :   216 kB /  73.1 kB in 3.4s
handlebars.js (167 kB) without sourcemap:
  ✓ babili             :  74.1 kB /  22.5 kB in 2.4s
  ✓ butternut          :  76.1 kB /  22.3 kB in 245ms
  ✓ closure            :  75.9 kB /  22.7 kB in 5s
  ✓ uglify             :  73.1 kB /  21.7 kB in 715ms
  ✓ uglify-mangle-only :  77.3 kB /  22.2 kB in 316ms
  ✓ uglify-es          :  73.1 kB /  21.7 kB in 850ms
handlebars.js (167 kB) with sourcemap:
  ✓ babili             :  74.1 kB /  22.5 kB in 2.4s
  ✓ butternut          :  76.1 kB /  22.3 kB in 279ms
  ✓ closure            :  75.9 kB /  22.7 kB in 4.6s
  ✓ uglify             :  73.2 kB /  21.7 kB in 966ms
  ✓ uglify-mangle-only :  77.4 kB /  22.2 kB in 364ms
  ✓ uglify-es          :  73.2 kB /  21.7 kB in 935ms
immutable.js (142 kB) without sourcemap:
  ✓ babili             :  61.7 kB /  16.6 kB in 2.6s
  ✓ butternut          :  58.4 kB /  15.9 kB in 214ms
  ✓ closure            :  60.9 kB /  17.3 kB in 4.9s
  ✓ uglify             :  56.6 kB /  15.6 kB in 590ms
  ✓ uglify-mangle-only :  59.5 kB /    16 kB in 206ms
  ✓ uglify-es          :  56.6 kB /  15.6 kB in 746ms
immutable.js (142 kB) with sourcemap:
  ✓ babili             :  61.7 kB /  16.6 kB in 2.6s
  ✓ butternut          :  58.4 kB /  15.9 kB in 403ms
  ✓ closure            :  60.9 kB /  17.3 kB in 4.9s
  ✓ uglify             :  56.7 kB /  15.7 kB in 673ms
  ✓ uglify-mangle-only :  59.5 kB /    16 kB in 246ms
  ✓ uglify-es          :  56.7 kB /  15.7 kB in 802ms
jquery.js (268 kB) without sourcemap:
  ✓ babili             :    96 kB /  32.9 kB in 5s
  ✓ butternut          :    89 kB /  30.6 kB in 328ms
  ✓ closure            :  89.4 kB /  31.8 kB in 6.8s
  ✓ uglify             :  86.8 kB /  30.4 kB in 1s
  ✓ uglify-mangle-only :  90.9 kB /  30.6 kB in 337ms
  ✓ uglify-es          :  86.8 kB /  30.4 kB in 1.3s
jquery.js (268 kB) with sourcemap:
  ✓ babili             :    96 kB /  32.9 kB in 5s
  ✓ butternut          :    89 kB /  30.6 kB in 402ms
  ✓ closure            :  89.4 kB /  31.8 kB in 6.8s
  ✓ uglify             :  86.8 kB /  30.5 kB in 1.1s
  ✓ uglify-mangle-only :    91 kB /  30.6 kB in 404ms
  ✓ uglify-es          :  86.8 kB /  30.5 kB in 1.3s
lodash.js (540 kB) without sourcemap:
  ✓ babili             :  77.9 kB /    26 kB in 6s
  ✓ butternut          :  73.9 kB /  25.8 kB in 444ms
  ✓ closure            :  74.6 kB /  25.3 kB in 7.9s
  ✓ uglify             :  71.2 kB /  25.2 kB in 1.2s
  ✓ uglify-mangle-only :  74.3 kB /  25.8 kB in 349ms
  ✓ uglify-es          :  71.2 kB /  25.2 kB in 1.5s
lodash.js (540 kB) with sourcemap:
  ✓ babili             :  77.9 kB /    26 kB in 5.8s
  ✓ butternut          :  73.9 kB /  25.8 kB in 556ms
  ✓ closure            :  74.6 kB /  25.3 kB in 7.9s
  ✓ uglify             :  71.2 kB /  25.2 kB in 1.2s
  ✓ uglify-mangle-only :  74.3 kB /  25.9 kB in 424ms
  ✓ uglify-es          :  71.2 kB /  25.2 kB in 1.6s
marked.js (28.7 kB) without sourcemap:
  ✓ babili             :  16.2 kB /  5.22 kB in 615ms
  ✓ butternut          :  16.4 kB /  5.24 kB in 45ms
  ✓ closure            :  16.3 kB /   5.3 kB in 2s
  ✓ uglify             :    16 kB /  5.18 kB in 139ms
  ✓ uglify-mangle-only :  16.5 kB /  5.24 kB in 60ms
  ✓ uglify-es          :    16 kB /  5.18 kB in 176ms
marked.js (28.7 kB) with sourcemap:
  ✓ babili             :  16.2 kB /  5.22 kB in 618ms
  ✓ butternut          :  16.4 kB /  5.24 kB in 49ms
  ✓ closure            :  16.3 kB /   5.3 kB in 2.1s
  ✓ uglify             :    16 kB /  5.21 kB in 199ms
  ✓ uglify-mangle-only :  16.6 kB /  5.27 kB in 60ms
  ✓ uglify-es          :    16 kB /  5.21 kB in 191ms
moment.js (129 kB) without sourcemap:
  ✓ babili             :  54.3 kB /  17.2 kB in 2.7s
  ✓ butternut          :  53.1 kB /  17.4 kB in 172ms
  ✓ closure            :  49.8 kB /  16.5 kB in 3.9s
  ✓ uglify             :  51.4 kB /  16.8 kB in 567ms
  ✓ uglify-mangle-only :  54.2 kB /  17.3 kB in 226ms
  ✓ uglify-es          :  51.4 kB /  16.8 kB in 704ms
moment.js (129 kB) with sourcemap:
  ✓ babili             :  54.3 kB /  17.2 kB in 2.7s
  ✓ butternut          :  53.1 kB /  17.4 kB in 207ms
  ✓ closure            :  49.8 kB /  16.5 kB in 4s
  ✓ uglify             :  51.4 kB /  16.9 kB in 610ms
  ✓ uglify-mangle-only :  54.3 kB /  17.3 kB in 253ms
  ✓ uglify-es          :  51.4 kB /  16.9 kB in 733ms
preact.js (20.5 kB) without sourcemap:
  ✓ babili             :  8.41 kB /  3.47 kB in 377ms
  ✓ butternut          :  8.15 kB /   3.4 kB in 29ms
  ✓ closure            :  7.89 kB /  3.35 kB in 2.4s
  ✓ uglify             :  8.07 kB /  3.35 kB in 119ms
  ✓ uglify-mangle-only :  8.46 kB /  3.38 kB in 31ms
  ✓ uglify-es          :  8.07 kB /  3.35 kB in 144ms
preact.js (20.5 kB) with sourcemap:
  ✓ babili             :  8.41 kB /  3.47 kB in 373ms
  ✓ butternut          :  8.15 kB /   3.4 kB in 32ms
  ✓ closure            :  7.89 kB /  3.35 kB in 2.3s
  ✓ uglify             :  8.11 kB /  3.38 kB in 115ms
  ✓ uglify-mangle-only :  8.49 kB /  3.41 kB in 38ms
  ✓ uglify-es          :  8.11 kB /  3.38 kB in 144ms
ramda.js (307 kB) without sourcemap:
  ✓ babili             :  47.1 kB /    12 kB in 2.1s
  ✓ butternut          :  44.5 kB /  11.8 kB in 205ms
  ✓ closure            :  45.5 kB /  12.9 kB in 4s
  ✓ uglify             :  42.8 kB /  11.4 kB in 1.8s
  ✓ uglify-mangle-only :  46.3 kB /  11.7 kB in 201ms
  ✓ uglify-es          :  42.8 kB /  11.4 kB in 2.1s
ramda.js (307 kB) with sourcemap:
  ✓ babili             :  47.1 kB /    12 kB in 1.8s
  ✓ butternut          :  44.5 kB /  11.8 kB in 254ms
  ✓ closure            :  45.5 kB /  12.9 kB in 4.2s
  ✓ uglify             :  42.8 kB /  11.5 kB in 1.8s
  ✓ uglify-mangle-only :  46.3 kB /  11.8 kB in 218ms
  ✓ uglify-es          :  42.8 kB /  11.5 kB in 2.1s
react-dom.js (646 kB) without sourcemap:
  ✓ babili             :   195 kB /  61.1 kB in 5.7s
  ✓ butternut          :   198 kB /  59.1 kB in 919ms
  ✓ closure            :   190 kB /  58.6 kB in 11.1s
  ✓ uglify             :   191 kB /  57.7 kB in 1.9s
  ✓ uglify-mangle-only :   218 kB /  60.7 kB in 733ms
  ✓ uglify-es          :   191 kB /  57.7 kB in 2.4s
react-dom.js (646 kB) with sourcemap:
  ✓ babili             :   195 kB /  61.1 kB in 6.2s
  ✓ butternut          :   198 kB /  59.1 kB in 911ms
  ✓ closure            :   190 kB /  58.6 kB in 11.3s
  ✓ uglify             :   191 kB /  57.7 kB in 1.9s
  ✓ uglify-mangle-only :   218 kB /  60.7 kB in 757ms
  ✓ uglify-es          :   191 kB /  57.7 kB in 2.4s
react.js (136 kB) without sourcemap:
  ✓ babili             :  39.2 kB /  13.5 kB in 1.3s
  ✓ butternut          :  40.2 kB /  13.2 kB in 133ms
  ✓ closure            :  45.6 kB /  14.9 kB in 3.6s
  ✓ uglify             :  38.6 kB /  12.7 kB in 389ms
  ✓ uglify-mangle-only :  44.5 kB /  13.6 kB in 153ms
  ✓ uglify-es          :  38.6 kB /  12.7 kB in 488ms
react.js (136 kB) with sourcemap:
  ✓ babili             :  39.2 kB /  13.5 kB in 1.3s
  ✓ butternut          :  40.2 kB /  13.2 kB in 169ms
  ✓ closure            :  45.6 kB /  14.9 kB in 3.9s
  ✓ uglify             :  38.6 kB /  12.7 kB in 432ms
  ✓ uglify-mangle-only :  44.5 kB /  13.6 kB in 175ms
  ✓ uglify-es          :  38.6 kB /  12.7 kB in 524ms
redux.js (30.8 kB) without sourcemap:
  ✓ babili             :   8.5 kB /  3.29 kB in 236ms
  ✓ butternut          :  8.76 kB /  3.23 kB in 27ms
  ✓ closure            :  10.7 kB /   3.8 kB in 1.9s
  ✓ uglify             :   8.3 kB /  3.05 kB in 88ms
  ✓ uglify-mangle-only :  9.13 kB /  3.23 kB in 30ms
  ✓ uglify-es          :   8.3 kB /  3.05 kB in 113ms
redux.js (30.8 kB) with sourcemap:
  ✓ babili             :   8.5 kB /  3.29 kB in 226ms
  ✓ butternut          :  8.76 kB /  3.23 kB in 35ms
  ✓ closure            :  10.7 kB /   3.8 kB in 1.8s
  ✓ uglify             :  8.33 kB /  3.08 kB in 98ms
  ✓ uglify-mangle-only :  9.16 kB /  3.26 kB in 37ms
  ✓ uglify-es          :  8.33 kB /  3.08 kB in 116ms
Rx.js (582 kB) without sourcemap:
  ✓ babili             :   150 kB /  30.5 kB in 8.4s
  ✓ butternut          :   143 kB /  29.8 kB in 557ms
  ✓ closure            :   141 kB /  29.8 kB in 8.3s
  ✓ uglify             :   141 kB /  28.9 kB in 1.4s
  ✓ uglify-mangle-only :   148 kB /  29.8 kB in 533ms
  ✓ uglify-es          :   141 kB /  28.9 kB in 1.8s
Rx.js (582 kB) with sourcemap:
  ✓ babili             :   150 kB /  30.5 kB in 8.5s
  ✓ butternut          :   143 kB /  29.8 kB in 756ms
  ✓ closure            :   141 kB /  29.8 kB in 8.4s
  ✓ uglify             :   141 kB /    29 kB in 1.7s
  ✓ uglify-mangle-only :   148 kB /  29.8 kB in 582ms
  ✓ uglify-es          :   141 kB /    29 kB in 1.9s
three.js (1.03 MB) without sourcemap:
  ✓ babili             :   540 kB /   134 kB in 17.3s
  ✓ butternut          :   516 kB /   129 kB in 1.6s
  ✓ closure            :   513 kB /   129 kB in 1m 12s
  ✓ uglify             :   509 kB /   128 kB in 4s
  ✓ uglify-mangle-only :   527 kB /   129 kB in 1.4s
  ✓ uglify-es          :   509 kB /   128 kB in 5s
three.js (1.03 MB) with sourcemap:
  ✓ babili             :   540 kB /   134 kB in 17.5s
  ✓ butternut          :   516 kB /   129 kB in 1.9s
  ✓ closure            :   513 kB /   129 kB in 1m 15.4s
  ✓ uglify             :   509 kB /   128 kB in 4.6s
  ✓ uglify-mangle-only :   527 kB /   129 kB in 1.6s
  ✓ uglify-es          :   509 kB /   128 kB in 5.2s
underscore.js (52.9 kB) without sourcemap:
  ✓ babili             :  16.9 kB /  5.96 kB in 662ms
  ✓ butternut          :  16.6 kB /  5.76 kB in 92ms
  ✓ closure            :  18.9 kB /  6.56 kB in 2.7s
  ✓ uglify             :  16.2 kB /  5.68 kB in 206ms
  ✓ uglify-mangle-only :  17.1 kB /  5.74 kB in 74ms
  ✓ uglify-es          :  16.2 kB /  5.68 kB in 261ms
underscore.js (52.9 kB) with sourcemap:
  ✓ babili             :  16.9 kB /  5.96 kB in 651ms
  ✓ butternut          :  16.6 kB /  5.76 kB in 91ms
  ✓ closure            :  18.9 kB /  6.56 kB in 2.8s
  ✓ uglify             :  16.2 kB /  5.71 kB in 245ms
  ✓ uglify-mangle-only :  17.1 kB /  5.77 kB in 92ms
  ✓ uglify-es          :  16.2 kB /  5.71 kB in 293ms
vue.js (253 kB) without sourcemap:
  ✓ babili             :   104 kB /  37.3 kB in 6.1s
  ✓ butternut          :  98.4 kB /  36.1 kB in 391ms
  ✓ closure            :  96.4 kB /  36.1 kB in 8.4s
  ✓ uglify             :  95.3 kB /  35.5 kB in 1.1s
  ✓ uglify-mangle-only :   104 kB /  36.5 kB in 384ms
  ✓ uglify-es          :  95.3 kB /  35.5 kB in 1.4s
vue.js (253 kB) with sourcemap:
  ✓ babili             :   104 kB /  37.3 kB in 6.2s
  ✓ butternut          :  98.4 kB /  36.1 kB in 474ms
  ✓ closure            :  96.4 kB /  36.1 kB in 8.5s
  ✓ uglify             :  95.3 kB /  35.5 kB in 1.2s
  ✓ uglify-mangle-only :   104 kB /  36.5 kB in 454ms
  ✓ uglify-es          :  95.3 kB /  35.5 kB in 1.5s
```
Note: Node v7.x has a [significant performance regression](https://github.com/nodejs/node/issues/11923) with the `instanceof` operator that makes uglify twice as slow. Reportedly Node v8.x will fix this issue.