### PR TITLE
Only remove from || onwards if left side of logical-or is truthy

### DIFF
--- a/src/program/types/LogicalExpression.js
+++ b/src/program/types/LogicalExpression.js
@@ -45,7 +45,7 @@ export default class LogicalExpression extends Node {
 				code.remove( this.start, this.right.start );
 				this.right.minify( code );
 			} else {
-				code.remove( this.left.start, this.end );
+				code.remove( this.left.end, this.end );
 				this.left.minify( code );
 			}
 		}

--- a/test/samples/expressions.js
+++ b/test/samples/expressions.js
@@ -27,17 +27,5 @@ module.exports = [
 		description: 'preserves whitespace around instanceof',
 		input: `var a = b instanceof c`,
 		output: `var a=b instanceof c`
-	},
-
-	{
-		description: 'rewrites && expression if value is known',
-		input: `var a = false && true`,
-		output: `var a=!1`
-	},
-
-	{
-		description: 'rewrites || expression if value is known',
-		input: `var a = false || true`,
-		output: `var a=!0`
 	}
 ];

--- a/test/samples/logical-expressions.js
+++ b/test/samples/logical-expressions.js
@@ -1,0 +1,61 @@
+module.exports = [
+	{
+		description: 'rewrites && expression if value is known',
+		input: `var a = false && true`,
+		output: `var a=!1`
+	},
+
+	{
+		description: 'rewrites && expression if left value is known',
+		input: `var a = true && false`,
+		output: `var a=!1`
+	},
+
+	{
+		description: 'rewrites && expression if left value is known and right is not minified',
+		input: `var a = true && 0`,
+		output: `var a=0`
+	},
+
+	{
+		description: 'rewrites && expression if left value is truthy and right is unknown',
+		input: `var a = true && b`,
+		output: `var a=b`
+	},
+
+	{
+		description: 'rewrites && expression if left value is falsy and right is unknown',
+		input: `var a = false && b`,
+		output: `var a=!1`
+	},
+
+	{
+		description: 'rewrites || expression if value is known',
+		input: `var a = false || true`,
+		output: `var a=!0`
+	},
+
+	{
+		description: 'rewrites || expression if left value is truthy',
+		input: `var a = true || false`,
+		output: `var a=!0`
+	},
+
+	{
+		description: 'rewrites || expression if left value is truthy but not true',
+		input: `var a = 1 || false`,
+		output: 'var a=1'
+	},
+
+	{
+		description: 'rewrites || expression if left value is truthy and right is unknown',
+		input: `var a = true || b`,
+		output: `var a=!0`
+	},
+
+	{
+		description: 'rewrites || expression if left value is falsy and right is unknown',
+		input: `var a = false || b`,
+		output: `var a=b`
+	}
+];


### PR DESCRIPTION
This fixes #54 - previously code was being removed from the _beginning_ of the left expression, whereas the whole lefthand expression should be kept.

Happy to put in test(s) too, just wasn't entirely sure which file to put it/them in. As it turns out it was also failing for any logical-or expression where the lefthand side was known-truthy (e.g. `x = 1 || 0; 1` was producing `x=,1`)