### PR TITLE
remove expression statements if the expression is a literal

### DIFF
--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -153,8 +153,9 @@ export default class BlockStatement extends Node {
 		// }
 
 		// TODO this is confusing. Also, maybe the parent should be responsible for making this determination
+		// TODO make a special case for 'use strict' — ensure it is at the start of the function block
 		const rewriteAsSequence = !this.parentIsFunction && statements.length > 0 && ( this.joinStatements || statements.every( statement => {
-			return statement.type === 'ExpressionStatement' ||
+			return ( statement.type === 'ExpressionStatement' && statement.expression.value !== 'use strict' ) ||
 			       statement.rewriteAsSequence;
 		}) );
 

--- a/src/program/types/ExpressionStatement.js
+++ b/src/program/types/ExpressionStatement.js
@@ -4,4 +4,16 @@ export default class ExpressionStatement extends Node {
 	getPrecedence () {
 		return this.expression.getPrecedence();
 	}
+
+	initialise ( scope ) {
+		if ( this.expression.type === 'Literal' ) {
+			// remove side-effect-free statements (TODO others, not just literals)...
+			if ( this.expression.value !== 'use strict' ) {
+				// ...unless this is a 'use strict' pragma (TODO remove if it's not the first node in a function/program block)
+				return;
+			}
+		}
+
+		super.initialise( scope );
+	}
 }

--- a/test/samples/dead-code-elimination.js
+++ b/test/samples/dead-code-elimination.js
@@ -101,6 +101,12 @@ module.exports = [
 				console.log( "running in production mode" );
 			}`,
 		output: `console.log("running in production mode")`
+	},
+
+	{
+		description: 'removes side-effect-free statement',
+		input: `"use strict"; 1; "test"; foo(); null; bar();`,
+		output: `"use strict";foo();bar()`
 	}
 
 	// TODO uncalled functions, unused variables...


### PR DESCRIPTION
This addresses part of #27 but doesn't close it — it only removes expression statements where the expression is a literal