### PR TITLE
Only inline BinaryExpression if both operands completely known

### DIFF
--- a/src/program/types/BinaryExpression.js
+++ b/src/program/types/BinaryExpression.js
@@ -1,5 +1,5 @@
 import Node from '../Node.js';
-import { UNKNOWN } from '../../utils/sentinels.js';
+import { TRUTHY, FALSY, UNKNOWN } from '../../utils/sentinels.js';
 import stringify from '../../utils/stringify.js';
 
 const calculators = {
@@ -50,7 +50,10 @@ export default class BinaryExpression extends Node {
 		const left = this.left.getValue();
 		const right = this.right.getValue();
 
-		if ( left === UNKNOWN || right === UNKNOWN ) return binaryExpressionPrecedence[ this.operator ];
+		if (
+			left === UNKNOWN || left === TRUTHY || left === FALSY ||
+			right === UNKNOWN || right === TRUTHY || right === FALSY
+		) return binaryExpressionPrecedence[ this.operator ];
 
 		return 20; // will be replaced by a literal
 	}
@@ -59,7 +62,10 @@ export default class BinaryExpression extends Node {
 		const left = this.left.getValue();
 		const right = this.right.getValue();
 
-		if ( left === UNKNOWN || right === UNKNOWN ) return UNKNOWN;
+		if (
+			left === UNKNOWN || left === TRUTHY || left === FALSY ||
+			right === UNKNOWN || right === TRUTHY || right === FALSY
+		) return UNKNOWN;
 
 		return calculators[ this.operator ]( left, right );
 	}

--- a/test/samples/arithmetic.js
+++ b/test/samples/arithmetic.js
@@ -36,6 +36,18 @@ module.exports = [
 	},
 
 	{
+		description: 'rewrites arithmetic with non-simple values',
+		input: `a = [ 1 ] + 2`,
+		output: `a="12"`
+	},
+
+	{
+		description: 'does not rewrite arithmetic with unknown but truthy values',
+		input: `a = [ b ] + 2`,
+		output: `a=[b]+2`
+	},
+
+	{
 		description: 'preserves space before --x expression',
 		input: `Math.sqrt(1 - --t * t)`,
 		output: `Math.sqrt(1- --t*t)`


### PR DESCRIPTION
This fixes #75, where one (or both) operands was either `TRUTHY` or `FALSY` but not a known value (i.e. arrays with unknown values, and object literals)