### PR TITLE
hoist vars out of removed blocks

### DIFF
--- a/src/program/types/IfStatement.js
+++ b/src/program/types/IfStatement.js
@@ -40,6 +40,12 @@ export default class IfStatement extends Node {
 
 		else if ( testValue ) { // if ( true ) {...}
 			this.consequent.initialise( scope );
+
+			if ( this.alternate && this.alternate.type === 'BlockStatement' ) {
+				this.alternate.scope.varDeclarations.forEach( name => {
+					scope.functionScope.hoistedVars.add( name );
+				});
+			}
 		}
 
 		else { // if ( false ) {...}
@@ -47,6 +53,12 @@ export default class IfStatement extends Node {
 				this.alternate.initialise( scope );
 			} else {
 				this.skip = true;
+			}
+
+			if ( this.consequent.type === 'BlockStatement' ) {
+				this.consequent.scope.varDeclarations.forEach( name => {
+					scope.functionScope.hoistedVars.add( name );
+				});
 			}
 		}
 	}

--- a/src/program/types/VariableDeclaration.js
+++ b/src/program/types/VariableDeclaration.js
@@ -6,6 +6,8 @@ export default class VariableDeclaration extends Node {
 		this.declarations.forEach( declarator => {
 			declarator.attachScope( scope );
 		});
+
+		scope.functionScope.varDeclarationNodes.push( this );
 	}
 
 	initialise ( scope ) {
@@ -38,6 +40,10 @@ export default class VariableDeclaration extends Node {
 			if ( declarator.start > c ) code.overwrite( c, declarator.start, i ? ',' : '' );
 			c = declarator.end;
 		}
+
+		// we may have been asked to declare some additional vars, if they were
+		// declared inside blocks that have been removed
+		if ( this.rideAlongs ) code.appendLeft( c, `,` + this.rideAlongs.join( ',' ) );
 
 		if ( this.end > c + 1 ) code.remove( c, this.end - 1 ); // TODO semi-less declarations
 

--- a/src/program/types/shared/FunctionNode.js
+++ b/src/program/types/shared/FunctionNode.js
@@ -28,9 +28,7 @@ export default class FunctionNode extends Node {
 			});
 		});
 
-		this.body.body.forEach( node => {
-			node.attachScope( this.scope );
-		});
+		this.body.attachScope( this.scope );
 	}
 
 	findVarDeclarations () {
@@ -38,8 +36,6 @@ export default class FunctionNode extends Node {
 	}
 
 	minify ( code ) {
-		this.scope.mangle( code );
-
 		let c = this.start;
 		let openParams;
 
@@ -70,6 +66,7 @@ export default class FunctionNode extends Node {
 		if ( this.params.length ) {
 			for ( let i = 0; i < this.params.length; i += 1 ) {
 				const param = this.params[i];
+				param.minify( code );
 
 				if ( param.start > c + 1 ) code.overwrite( c, param.start, i ? ',' : openParams );
 				c = param.end;
@@ -82,6 +79,6 @@ export default class FunctionNode extends Node {
 			code.overwrite( c, this.body.start, `${openParams})` );
 		}
 
-		super.minify( code );
+		this.body.minify( code );
 	}
 }

--- a/test/samples/var-declarations.js
+++ b/test/samples/var-declarations.js
@@ -101,6 +101,6 @@ module.exports = [
 			}
 			console.log(x, y);
 			console.log(x, y);`,
-		output: `var x=1,y,z;console.log(x,y),console.log(x,y)}`
+		output: `var x=1,y,z;console.log(x,y);console.log(x,y)`
 	}
 ];

--- a/test/samples/var-declarations.js
+++ b/test/samples/var-declarations.js
@@ -50,5 +50,57 @@ module.exports = [
 				return thing;
 			};`,
 		output: `var x=function(b){var a=fn();return a}`
+	},
+
+	{
+		description: 'preserves var declarations in removed blocks',
+		input: `
+			function foo () {
+				if(false) {
+					var x = 1;
+				}
+				console.log(x);
+				console.log(x);
+			}`,
+		output: `function foo(){var a;console.log(a);console.log(a)}`
+	},
+
+	{
+		description: 'merges var declarations in removed blocks with non-removed declarations',
+		input: `
+			function foo () {
+				var x = 1;
+				if(false) {
+					var y = 2;
+					var z = 3; // unused, should be removed
+				}
+				console.log(x, y);
+				console.log(x, y);
+			}`,
+		output: `function foo(){var a=1,b;console.log(a,b);console.log(a,b)}`
+	},
+
+	{
+		description: 'preserves var declarations in removed blocks at top level',
+		input: `
+			if(false) {
+				var x = 1;
+			}
+			console.log(x);
+			console.log(x);`,
+		output: `var x;console.log(x),console.log(x)`
+	},
+
+	{
+		description: 'merges var declarations in removed blocks with non-removed declarations at top level',
+		input: `
+			var x = 1;
+			if(false) {
+				var y = 2;
+				var z = 3; // unused, but is top-level so should be preserved
+			}
+			console.log(x, y);
+			console.log(x, y);`,
+		output: `var x=1,y,z;console.log(x,y),console.log(x,y)}`
 	}
 ];


### PR DESCRIPTION
This addresses #51 — situations in which a variable is declared inside a block that gets removed, but is used *outside* the block. (In other words, idiotic code.) Not 100% happy with the implementation, but it works which is the most important thing — can always revisit the internals later.