### PR TITLE
Preserve parentheses around object expressions/patterns where necessary

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ export function squash ( source, options = {} ) {
 		ast = parse( source, {
 			ecmaVersion: 8,
 			preserveParens: true,
-			sourceType: 'module'
+			sourceType: 'module',
+			allowReserved: true
 		});
 		if ( DEBUG ) stats.timeEnd( 'parse' );
 	} catch ( err ) {

--- a/src/program/check.js
+++ b/src/program/check.js
@@ -59,7 +59,8 @@ function createRepro ( source, ast, line, column ) {
 			ecmaVersion: 8,
 			preserveParens: true,
 			sourceType: 'module',
-			allowReturnOutsideFunction: true
+			allowReturnOutsideFunction: true,
+			allowReserved: true
 		});
 
 		const { code } = new Program( slice, ast, null ).export({});
@@ -68,7 +69,8 @@ function createRepro ( source, ast, line, column ) {
 			parse( code, {
 				ecmaVersion: 8,
 				sourceType: 'module',
-				allowReturnOutsideFunction: true
+				allowReturnOutsideFunction: true,
+				allowReserved: true
 			});
 		} catch ( err ) {
 			return {

--- a/src/program/types/ExpressionStatement.js
+++ b/src/program/types/ExpressionStatement.js
@@ -6,8 +6,16 @@ export default class ExpressionStatement extends Node {
 		return true;
 	}
 
+	getLeftHandSide () {
+		return this.expression.getLeftHandSide();
+	}
+
 	getPrecedence () {
 		return this.expression.getPrecedence();
+	}
+
+	getRightHandSide () {
+		return this.expression.getRightHandSide();
 	}
 
 	initialise ( scope ) {

--- a/src/program/types/LogicalExpression.js
+++ b/src/program/types/LogicalExpression.js
@@ -3,7 +3,14 @@ import { UNKNOWN } from '../../utils/sentinels.js';
 
 export default class LogicalExpression extends Node {
 	getLeftHandSide () {
-		return this.left.getLeftHandSide();
+		const leftValue = this.left.getValue();
+
+		if ( leftValue === UNKNOWN ) return this.left.getLeftHandSide();
+
+		return ( this.operator === '&&' ?
+			( leftValue ? this.right : this.left ) :
+			( leftValue ? this.left : this.right )
+		).getLeftHandSide();
 	}
 
 	getPrecedence () {
@@ -13,6 +20,17 @@ export default class LogicalExpression extends Node {
 		if ( leftValue === UNKNOWN || rightValue === UNKNOWN ) return this.operator === '&&' ? 6 : 5;
 
 		return 20; // will be replaced by a literal
+	}
+
+	getRightHandSide () {
+		const leftValue = this.left.getValue();
+
+		if ( leftValue === UNKNOWN ) return this.right.getRightHandSide();
+
+		return ( this.operator === '&&' ?
+			( leftValue ? this.right : this.left ) :
+			( leftValue ? this.left : this.right )
+		).getRightHandSide();
 	}
 
 	getValue () {

--- a/src/program/types/MemberExpression.js
+++ b/src/program/types/MemberExpression.js
@@ -9,6 +9,10 @@ function isValidIdentifier ( str ) {
 }
 
 export default class MemberExpression extends Node {
+	getLeftHandSide () {
+		return this.object.getLeftHandSide();
+	}
+
 	getValue () {
 		const objectValue = this.object.getValue();
 		if ( !objectValue || objectValue === UNKNOWN ) return UNKNOWN;
@@ -24,6 +28,10 @@ export default class MemberExpression extends Node {
 
 	getPrecedence () {
 		return 18;
+	}
+
+	getRightHandSide () {
+		return this;
 	}
 
 	minify ( code ) {

--- a/src/program/types/ParenthesizedExpression.js
+++ b/src/program/types/ParenthesizedExpression.js
@@ -4,6 +4,10 @@ function shouldRemoveParens ( expression, parent ) {
 	const expressionPrecedence = expression.getPrecedence();
 	const parentPrecedence = parent.getPrecedence();
 
+	if ( /^Object/.test( expression.getLeftHandSide().type ) || /^Object/.test( expression.getRightHandSide().type ) ) {
+		return false;
+	}
+
 	if ( expression.type === 'CallExpression' ) {
 		return expression.callee.type === 'FunctionExpression'; // TODO is this right?
 	}

--- a/test/samples/misc.js
+++ b/test/samples/misc.js
@@ -15,5 +15,14 @@ module.exports = [
 		description: 'handles weird \u2028 and \u2029 characters',
 		input: `var ws = '\\u2028' + '\\u2029';`,
 		output: `var ws="\\u2028\\u2029"`
+	},
+
+	{
+		description: 'allows reserved words',
+		input: `
+			var obj = {
+				await: function await () {}
+			};`,
+		output: `var obj={await:function a(){}}`
 	}
 ];

--- a/test/samples/objects.js
+++ b/test/samples/objects.js
@@ -44,5 +44,20 @@ module.exports = [
 				}
 			}`,
 		output: `var obj={async foo(){}}`
+	},
+
+	{
+		description: 'preserves parens around object literals',
+		input: `
+			if (true && {}.foo) {
+				bar();
+			}`,
+		output: `({}.foo)&&bar()`
+	},
+
+	{
+		description: 'preserves parens around object patterns',
+		input: `({ foo, bar, baz } = obj);`,
+		output: `({foo,bar,baz}=obj)`
 	}
 ];

--- a/test/test.js
+++ b/test/test.js
@@ -14,8 +14,8 @@ const butternut = require(process.env.COVERAGE ? '../src/index.js' : process.env
 require('source-map-support').install();
 require('console-group').install();
 
-function equal(a, b) {
-	assert.equal(showInvisibles(a), showInvisibles(b));
+function equal(a, b, message) {
+	assert.equal(showInvisibles(a), showInvisibles(b), message);
 }
 
 function showInvisibles(str) {
@@ -64,7 +64,7 @@ describe('butternut', function () {
 
 						// idempotency test
 						if (sample.idempotent !== false ) {
-							equal(butternut.squash(code, sample.options).code, code);
+							equal(butternut.squash(code, sample.options).code, code, 'failed idempotency check');
 						}
 					}
 				});


### PR DESCRIPTION
Fixes #79. As a sidenote, we're now calling things like `getLeftHandSide` and `getValue` quite a lot, we should probably memoize them