### PR TITLE
Handle IfStatement with empty consequent+alternate but non-removable test

### DIFF
--- a/src/program/types/IfStatement.js
+++ b/src/program/types/IfStatement.js
@@ -140,6 +140,9 @@ export default class IfStatement extends Node {
 					if ( canRemoveTest ) {
 						code.remove( this.start, this.end );
 						this.removed = true;
+					} else {
+						code.remove( this.start, this.test.start );
+						code.remove( this.test.end, this.end );
 					}
 				} else if ( this.alternate.canSequentialise() ) {
 					let alternatePrecedence;

--- a/test/samples/if.js
+++ b/test/samples/if.js
@@ -184,6 +184,12 @@ module.exports = [
 	},
 
 	{
+		description: 'removes empty if block if both consequent and alternate are empty',
+		input: `if ( foo() ) {} else {}`,
+		output: `foo()`
+	},
+
+	{
 		description: 'removes empty if block in complex if-else',
 		input: `if ( foo () ) {} else { var bar = 'baz'; }`,
 		output: `if(!foo())var bar='baz'`


### PR DESCRIPTION
This handles the case of:

```js
if ( foo() ) {
  // empty
} else {
  // also empty
}
```

... which currently is being minified as:

```js
if ( foo() ) {
  // empty
} else
```

Not entirely sure why you'd have _both_ consequent + alternate be empty but apparently I've written a few myself by repeatedly commenting stuff out.