### PR TITLE
Only collapse `a = a OP b` to `a OP= b` for whitelisted operators.

### DIFF
--- a/src/program/types/AssignmentExpression.js
+++ b/src/program/types/AssignmentExpression.js
@@ -6,6 +6,8 @@ let commutative = {};
 // operating on strings
 for ( let operator of '*&^|' ) commutative[ operator ] = true;
 
+const collapsibleOperators = '** * / % + - << >> >>> & ^ |'.split( ' ' );
+
 export default class AssignmentExpression extends Node {
 	getLeftHandSide () {
 		return this.left.getLeftHandSide();
@@ -32,7 +34,7 @@ export default class AssignmentExpression extends Node {
 		}
 
 		// special case – `a = a + 1` -> `a += 1`
-		if ( this.operator === '=' && this.left.type === 'Identifier' && this.right.type === 'BinaryExpression' ) {
+		if ( this.operator === '=' && this.left.type === 'Identifier' && this.right.type === 'BinaryExpression' && ~collapsibleOperators.indexOf( this.right.operator ) ) {
 			if ( this.right.left.type === 'Identifier' && ( this.right.left.name === this.left.name ) ) {
 				code.appendLeft( this.left.end, this.right.operator );
 				code.remove( this.right.start, this.right.right.start );

--- a/test/samples/arithmetic.js
+++ b/test/samples/arithmetic.js
@@ -30,6 +30,12 @@ module.exports = [
 	},
 
 	{
+		description: 'does not rewrite `a = a !== false` as `a!===!1`',
+		input: `a = a !== false`,
+		output: `a=a!==!1`
+	},
+
+	{
 		description: 'rewrites arithmetic expression with value',
 		input: `a = 1 + 2 * 3`,
 		output: `a=7`


### PR DESCRIPTION
This fixes as least one issue in #92, although I didn't dig deep enough on that one to know whether this was the _only_ issue there.