### PR TITLE
compare with uglify

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ const rimraf = require('rimraf');
 const child_process = require('child_process');
 const assert = require('assert');
 const glob = require('glob');
+const UglifyJS = require('uglify-es');
 
 if (process.env.COVERAGE) {
 	require('reify');
@@ -65,6 +66,15 @@ describe('butternut', function () {
 						// idempotency test
 						if (sample.idempotent !== false ) {
 							equal(butternut.squash(code, sample.options).code, code, 'failed idempotency check');
+						}
+
+						const uglified = UglifyJS.minify(sample.input);
+						if ('code' in uglified) {
+							if (uglified.code.length < code.length) {
+								console.warn(`⚠️   uglify-es generated smaller output:\n      butternut: ${code}\n      uglify-es: ${uglified.code}`);
+							}
+						} else {
+							// uglify failed to minify this sample
 						}
 					}
 				});


### PR DESCRIPTION
This adds a warning if Uglify does a better job of compressing a test sample than Butternut. In some cases Uglify fails (`async`, anonymous function declaration default exports), and in some cases it generates bad output (`class a||b{}`), but in many cases it's just doing a better job, and we should steal those optimisations.

A few examples:

## Removing unused function expression IDs

```
⚠️   uglify-es generated smaller output:
      butternut: var foo=function a(b,c){console.log(b);console.log(c)}
      uglify-es: var foo=function(o,l){console.log(o),console.log(l)};
```

## Removing empty IIFEs

```
⚠️   uglify-es generated smaller output:
      butternut: !function(){}()
      uglify-es:
```

## Writing `Infinity` as `1/0`

```
⚠️   uglify-es generated smaller output:
      butternut: x=Infinity
      uglify-es: x=1/0;
```

## Inlining certain values

```
⚠️   uglify-es generated smaller output:
      butternut: function foo(){var a=1,b=2;console.log(a,b)}
      uglify-es: function foo(){console.log(1,2)}
```

## Inlining function calls and removing redundant return statements

```
⚠️   uglify-es generated smaller output:
      butternut: function foo(){a();return;function a(){console.log('bar')}}
      uglify-es: function foo(){!function(){console.log("bar")}()}
```

## Not parenthesizing assignment expressions

```
⚠️   uglify-es generated smaller output:
      butternut: foo?(a=b):(a=c)
      uglify-es: foo?a=b:a=c;
```

## Inlining return values from functions

```
⚠️   uglify-es generated smaller output:
      butternut: function x(){var a=function(){return 42};if(y){var b=a();console.log(b)}}
      uglify-es: function x(){if(y){console.log(42)}}
```

## Optimising `if(a)return b;else return c`

```
⚠️   uglify-es generated smaller output:
      butternut: function foo(){if(a)return b;else return c}
      uglify-es: function foo(){return a?b:c}
```

## Removing parens in NewExpression without parameters

```
⚠️   uglify-es generated smaller output:
      butternut: new Foo()
      uglify-es: new Foo;
```

There's a couple of others but those are the main ones.