### PR TITLE
Better mangling

### DIFF
--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -110,7 +110,7 @@ export default class BlockStatement extends Node {
 		return this;
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		let executionIsBroken = false;
 		let maybeReturnNode;
 		let hasDeclarationsAfterBreak = false;
@@ -124,7 +124,7 @@ export default class BlockStatement extends Node {
 			if ( executionIsBroken ) {
 				if ( shouldPreserveAfterReturn[ node.type ] ) {
 					hasDeclarationsAfterBreak = true;
-					node.initialise( this.scope || scope );
+					node.initialise( program, this.scope || scope );
 				}
 
 				continue;
@@ -133,7 +133,7 @@ export default class BlockStatement extends Node {
 			maybeReturnNode = breaksExecution( node );
 			if ( maybeReturnNode ) executionIsBroken = true;
 
-			node.initialise( this.scope || scope );
+			node.initialise( program, this.scope || scope );
 
 			if ( canCollapseReturns ) {
 				if ( node.preventsCollapsedReturns( returnStatements ) ) {

--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -50,7 +50,7 @@ function isVarDeclaration ( node ) {
 }
 
 export default class BlockStatement extends Node {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
 		this.parentIsFunction = /Function/.test( this.parent.type );
 
 		if ( this.parentIsFunction ) {
@@ -63,7 +63,7 @@ export default class BlockStatement extends Node {
 		}
 
 		for ( let i = 0; i < this.body.length; i += 1 ) {
-			this.body[i].attachScope( this.scope );
+			this.body[i].attachScope( program, this.scope );
 		}
 	}
 

--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -167,9 +167,9 @@ export default class BlockStatement extends Node {
 		return true;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.scope ) {
-			this.scope.mangle( code );
+			this.scope.mangle( code, chars );
 		}
 
 		let insertedVarDeclaration = '';
@@ -223,7 +223,7 @@ export default class BlockStatement extends Node {
 			for ( let i = 0; i < statements.length; i += 1 ) {
 				const statement = statements[i];
 
-				statement.minify( code );
+				statement.minify( code, chars );
 
 				if ( !statement.collapsed ) {
 					if ( statement.start > lastEnd ) code.remove( lastEnd, statement.start );
@@ -300,7 +300,7 @@ export default class BlockStatement extends Node {
 	// 	}
 
 	// 	statements.forEach( statement => {
-	// 		statement.minify( code );
+	// 		statement.minify( code, chars );
 	// 	});
 	// }
 }

--- a/src/program/BlockStatement.js
+++ b/src/program/BlockStatement.js
@@ -168,7 +168,9 @@ export default class BlockStatement extends Node {
 	}
 
 	minify ( code ) {
-		if ( this.scope ) this.scope.mangle( code );
+		if ( this.scope ) {
+			this.scope.mangle( code );
+		}
 
 		let insertedVarDeclaration = '';
 

--- a/src/program/Node.js
+++ b/src/program/Node.js
@@ -110,7 +110,7 @@ export default class Node {
 		code.move( this.getLeftHandSide().start, this.getRightHandSide().end, position );
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		for ( var key of this.keys ) {
 			const value = this[ key ];
 
@@ -118,10 +118,10 @@ export default class Node {
 				if ( 'length' in value ) {
 					let i = value.length;
 					while ( i-- ) {
-						if ( value[i] ) value[i].minify( code );
+						if ( value[i] ) value[i].minify( code, chars );
 					}
 				} else {
-					value.minify( code );
+					value.minify( code, chars );
 				}
 			}
 		}

--- a/src/program/Node.js
+++ b/src/program/Node.js
@@ -66,7 +66,7 @@ export default class Node {
 		return UNKNOWN;
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		this.skip = false;
 
 		for ( var key of this.keys ) {
@@ -76,10 +76,10 @@ export default class Node {
 				if ( 'length' in value ) {
 					let i = value.length;
 					while ( i-- ) {
-						if ( value[i] ) value[i].initialise( scope );
+						if ( value[i] ) value[i].initialise( program, scope );
 					}
 				} else {
-					value.initialise( scope );
+					value.initialise( program, scope );
 				}
 			}
 		}

--- a/src/program/Node.js
+++ b/src/program/Node.js
@@ -16,7 +16,7 @@ export default class Node {
 		code.appendLeft( this.getRightHandSide().end, content );
 	}
 
-	attachScope ( scope ) {
+	attachScope ( program, scope ) {
 		for ( var key of this.keys ) {
 			const value = this[ key ];
 
@@ -24,10 +24,10 @@ export default class Node {
 				if ( 'length' in value ) {
 					let i = value.length;
 					while ( i-- ) {
-						if ( value[i] ) value[i].attachScope( scope );
+						if ( value[i] ) value[i].attachScope( program, scope );
 					}
 				} else {
-					value.attachScope( scope );
+					value.attachScope( program, scope );
 				}
 			}
 		}

--- a/src/program/Program.js
+++ b/src/program/Program.js
@@ -7,6 +7,11 @@ import check from './check.js';
 const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$0123456789'.split('');
 const digit = /\d/;
 
+const naturalOrder = {};
+chars.forEach( ( char, i ) => {
+	naturalOrder[char] = i;
+});
+
 export default function Program ( source, ast, options, stats ) {
 	this.options = options;
 	this.stats = stats;
@@ -47,7 +52,7 @@ export default function Program ( source, ast, options, stats ) {
 	chars.sort( ( a, b ) => {
 		if ( digit.test( a ) && !digit.test( b ) ) return 1;
 		if ( digit.test( b ) && !digit.test( a ) ) return -1;
-		return this.charFrequency[b] - this.charFrequency[a];
+		return ( this.charFrequency[b] - this.charFrequency[a] ) || ( naturalOrder[a] - naturalOrder[b] );
 	});
 
 	if ( DEBUG ) stats.time( 'minify' );

--- a/src/program/Program.js
+++ b/src/program/Program.js
@@ -4,6 +4,8 @@ import BlockStatement from './BlockStatement.js';
 import Scope from './Scope.js';
 import check from './check.js';
 
+const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$0123456789'.split('');
+
 export default function Program ( source, ast, options, stats ) {
 	this.options = options;
 	this.stats = stats;
@@ -30,7 +32,12 @@ export default function Program ( source, ast, options, stats ) {
 	});
 
 	this.body.body.forEach( node => {
-		node.attachScope( this.body.scope );
+		node.attachScope( this, this.body.scope );
+	});
+
+	this.charFrequency = {};
+	chars.forEach( char => {
+		this.charFrequency[char] = 0;
 	});
 
 	this.body.initialise( this, this.body.scope );
@@ -42,6 +49,12 @@ export default function Program ( source, ast, options, stats ) {
 }
 
 Program.prototype = {
+	addWord ( word ) {
+		for ( let i = 0; i < word.length; i += 1 ) {
+			this.charFrequency[word[i]] += 1;
+		}
+	},
+
 	export ( options ) {
 		const stats = this.stats;
 

--- a/src/program/Program.js
+++ b/src/program/Program.js
@@ -5,6 +5,7 @@ import Scope from './Scope.js';
 import check from './check.js';
 
 const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_$0123456789'.split('');
+const digit = /\d/;
 
 export default function Program ( source, ast, options, stats ) {
 	this.options = options;
@@ -42,6 +43,12 @@ export default function Program ( source, ast, options, stats ) {
 
 	this.body.initialise( this, this.body.scope );
 	if ( DEBUG ) stats.timeEnd( 'init body' );
+
+	this.body.scope.chars = chars.sort( ( a, b ) => {
+		if ( digit.test( a ) && !digit.test( b ) ) return 1;
+		if ( digit.test( b ) && !digit.test( a ) ) return -1;
+		return this.charFrequency[b] - this.charFrequency[a];
+	});
 
 	if ( DEBUG ) stats.time( 'minify' );
 	this.body.minify( this.magicString );

--- a/src/program/Program.js
+++ b/src/program/Program.js
@@ -44,14 +44,14 @@ export default function Program ( source, ast, options, stats ) {
 	this.body.initialise( this, this.body.scope );
 	if ( DEBUG ) stats.timeEnd( 'init body' );
 
-	this.body.scope.chars = chars.sort( ( a, b ) => {
+	chars.sort( ( a, b ) => {
 		if ( digit.test( a ) && !digit.test( b ) ) return 1;
 		if ( digit.test( b ) && !digit.test( a ) ) return -1;
 		return this.charFrequency[b] - this.charFrequency[a];
 	});
 
 	if ( DEBUG ) stats.time( 'minify' );
-	this.body.minify( this.magicString );
+	this.body.minify( this.magicString, chars );
 	if ( DEBUG ) stats.timeEnd( 'minify' );
 }
 

--- a/src/program/Program.js
+++ b/src/program/Program.js
@@ -33,7 +33,7 @@ export default function Program ( source, ast, options, stats ) {
 		node.attachScope( this.body.scope );
 	});
 
-	this.body.initialise( this.body.scope );
+	this.body.initialise( this, this.body.scope );
 	if ( DEBUG ) stats.timeEnd( 'init body' );
 
 	if ( DEBUG ) stats.time( 'minify' );

--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -164,6 +164,8 @@ Scope.prototype = {
 			return alias;
 		}
 
+		// TODO sort declarations by number of instances?
+
 		Object.keys( this.declarations ).forEach( name => {
 			const declaration = this.declarations[ name ];
 			if ( declaration.instances.length === 0 ) return;

--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -36,11 +36,6 @@ export default function Scope ( options ) {
 }
 
 Scope.prototype = {
-	addAlias ( alias ) {
-		this.aliases[ alias ] = true;
-		if ( this.parent ) this.parent.addAlias( alias );
-	},
-
 	addDeclaration ( identifier, kind ) {
 		if ( kind === 'var' && this.isBlockScope ) {
 			this.varDeclarations.add( identifier.name );
@@ -126,10 +121,6 @@ Scope.prototype = {
 	contains ( name ) {
 		return this.declarations[ name ] ||
 		       ( this.parent ? this.parent.contains( name ) : false );
-	},
-
-	containsAlias ( alias ) {
-		return this.aliases[ alias ] || ( this.parent && this.parent.containsAlias( alias ) );
 	},
 
 	createIdentifier ( used ) {

--- a/src/program/Scope.js
+++ b/src/program/Scope.js
@@ -166,6 +166,9 @@ Scope.prototype = {
 	mangle ( code ) {
 		if ( !this.canMangle ) return;
 
+		const chars = this.chars || this.parent.chars;
+		console.log( chars );
+
 		let used = Object.create( null );
 
 		Object.keys( this.references ).forEach( reference => {

--- a/src/program/types/ArrowFunctionExpression.js
+++ b/src/program/types/ArrowFunctionExpression.js
@@ -3,14 +3,14 @@ import Scope from '../Scope.js';
 import extractNames from '../extractNames.js';
 
 export default class ArrowFunctionExpression extends Node {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
 		this.scope = new Scope({
 			block: false,
 			parent
 		});
 
 		this.params.forEach( param => {
-			param.attachScope( this.scope );
+			param.attachScope( program, this.scope );
 
 			extractNames( param ).forEach( node => {
 				node.declaration = this;
@@ -20,10 +20,10 @@ export default class ArrowFunctionExpression extends Node {
 
 		if ( this.body.type === 'BlockStatement' ) {
 			this.body.body.forEach( node => {
-				node.attachScope( this.scope );
+				node.attachScope( program, this.scope );
 			});
 		} else {
-			this.body.attachScope( this.scope );
+			this.body.attachScope( program, this.scope );
 		}
 
 	}

--- a/src/program/types/ArrowFunctionExpression.js
+++ b/src/program/types/ArrowFunctionExpression.js
@@ -40,8 +40,8 @@ export default class ArrowFunctionExpression extends Node {
 		return this.params.length === 1 ? this.params[0] : this;
 	}
 
-	minify ( code ) {
-		this.scope.mangle( code );
+	minify ( code, chars ) {
+		this.scope.mangle( code, chars );
 
 		let c = this.start;
 		if ( this.async ) c += 5;
@@ -53,7 +53,7 @@ export default class ArrowFunctionExpression extends Node {
 		}
 
 		else if ( this.params.length === 1 ) {
-			this.params[0].minify( code );
+			this.params[0].minify( code, chars );
 
 			if ( this.params[0].type === 'Identifier' ) {
 				// remove parens
@@ -79,7 +79,7 @@ export default class ArrowFunctionExpression extends Node {
 
 		else {
 			this.params.forEach( ( param, i ) => {
-				param.minify( code );
+				param.minify( code, chars );
 				if ( param.start > c + 1 ) code.overwrite( c, param.start, i ? ',' : '(' );
 				c = param.end;
 			});
@@ -89,6 +89,6 @@ export default class ArrowFunctionExpression extends Node {
 			}
 		}
 
-		this.body.minify( code );
+		this.body.minify( code, chars );
 	}
 }

--- a/src/program/types/ArrowFunctionExpression.js
+++ b/src/program/types/ArrowFunctionExpression.js
@@ -28,8 +28,8 @@ export default class ArrowFunctionExpression extends Node {
 
 	}
 
-	initialise () {
-		super.initialise( this.scope );
+	initialise ( program ) {
+		super.initialise( program, this.scope );
 	}
 
 	findVarDeclarations () {

--- a/src/program/types/AssignmentExpression.js
+++ b/src/program/types/AssignmentExpression.js
@@ -17,7 +17,7 @@ export default class AssignmentExpression extends Node {
 		return 3;
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( this.left.type === 'Identifier' ) {
 			const declaration = scope.findDeclaration( this.left.name );
 			if ( declaration && declaration.kind === 'const' ) {
@@ -25,7 +25,7 @@ export default class AssignmentExpression extends Node {
 			}
 		}
 
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 
 	minify ( code ) {

--- a/src/program/types/AssignmentExpression.js
+++ b/src/program/types/AssignmentExpression.js
@@ -28,7 +28,7 @@ export default class AssignmentExpression extends Node {
 		super.initialise( program, scope );
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.right.start > this.left.end + this.operator.length ) {
 			code.overwrite( this.left.end, this.right.start, this.operator );
 		}
@@ -39,7 +39,7 @@ export default class AssignmentExpression extends Node {
 				code.appendLeft( this.left.end, this.right.operator );
 				code.remove( this.right.start, this.right.right.start );
 
-				this.right.right.minify( code );
+				this.right.right.minify( code, chars );
 				return;
 			}
 
@@ -48,11 +48,11 @@ export default class AssignmentExpression extends Node {
 				code.appendLeft( this.left.end, this.right.operator );
 				code.remove( this.right.left.end, this.right.end );
 
-				this.right.left.minify( code );
+				this.right.left.minify( code, chars );
 				return;
 			}
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/BinaryExpression.js
+++ b/src/program/types/BinaryExpression.js
@@ -65,7 +65,7 @@ export default class BinaryExpression extends Node {
 		return calculators[ this.operator ]( left, right );
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const value = this.getValue();
 
 		if ( value !== UNKNOWN ) {
@@ -87,7 +87,7 @@ export default class BinaryExpression extends Node {
 				code.overwrite( this.left.end, this.right.start, operator );
 			}
 
-			super.minify( code );
+			super.minify( code, chars );
 		}
 	}
 }

--- a/src/program/types/BinaryExpression.js
+++ b/src/program/types/BinaryExpression.js
@@ -56,6 +56,7 @@ export default class BinaryExpression extends Node {
 			getValuePrecedence( value );
 	}
 
+	// TODO `program.addWord( stringify( this.getValue() ) )`...
 	getValue () {
 		const left = this.left.getValue();
 		const right = this.right.getValue();

--- a/src/program/types/CallExpression.js
+++ b/src/program/types/CallExpression.js
@@ -89,7 +89,7 @@ export default class CallExpression extends Node {
 		return calleeValue.apply( contextValue, argumentValues );
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( this.callee.type === 'Identifier' && this.callee.name === 'eval' && !scope.contains( 'eval' ) ) {
 			if ( this.program.options.allowDangerousEval ) {
 				scope.deopt();
@@ -97,7 +97,7 @@ export default class CallExpression extends Node {
 				this.error( 'Use of direct eval prevents effective minification and can introduce security vulnerabilities. Use `allowDangerousEval: true` if you know what you\'re doing' );
 			}
 		}
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 
 	minify ( code ) {

--- a/src/program/types/CallExpression.js
+++ b/src/program/types/CallExpression.js
@@ -100,7 +100,7 @@ export default class CallExpression extends Node {
 		super.initialise( program, scope );
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const value = this.getValue();
 
 		if ( value !== UNKNOWN ) {
@@ -129,6 +129,6 @@ export default class CallExpression extends Node {
 			code.overwrite( this.callee.end, this.end, '()' );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/CatchClause.js
+++ b/src/program/types/CatchClause.js
@@ -3,7 +3,7 @@ import Scope from '../Scope.js';
 import extractNames from '../extractNames.js';
 
 export default class CatchClause extends Node {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
 		this.scope = new Scope({
 			block: true,
 			parent
@@ -14,15 +14,16 @@ export default class CatchClause extends Node {
 		});
 
 		for ( let i = 0; i < this.body.body.length; i += 1 ) {
-			this.body.body[i].attachScope( this.scope );
+			this.body.body[i].attachScope( program, this.scope );
 		}
 
 		if ( this.finalizer ) {
-			this.finalizer.attachScope( this.scope );
+			this.finalizer.attachScope( program, this.scope );
 		}
 	}
 
 	initialise ( program ) {
+		program.addWord( 'catch' );
 		super.initialise( program, this.scope );
 	}
 

--- a/src/program/types/CatchClause.js
+++ b/src/program/types/CatchClause.js
@@ -22,8 +22,8 @@ export default class CatchClause extends Node {
 		}
 	}
 
-	initialise () {
-		super.initialise( this.scope );
+	initialise ( program ) {
+		super.initialise( program, this.scope );
 	}
 
 	minify ( code ) {

--- a/src/program/types/CatchClause.js
+++ b/src/program/types/CatchClause.js
@@ -27,8 +27,8 @@ export default class CatchClause extends Node {
 		super.initialise( program, this.scope );
 	}
 
-	minify ( code ) {
-		this.scope.mangle( code );
+	minify ( code, chars ) {
+		this.scope.mangle( code, chars );
 
 		if ( this.param.start > this.start + 6 ) {
 			code.overwrite( this.start + 5, this.param.start, '(' );
@@ -38,6 +38,6 @@ export default class CatchClause extends Node {
 			code.overwrite( this.param.end, this.body.start, ')' );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/ClassBody.js
+++ b/src/program/types/ClassBody.js
@@ -7,14 +7,14 @@ export default class ClassBody extends Node {
 		}
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start + 1;
 
 		for ( let i = 0; i < this.body.length; i += 1 ) {
 			const method = this.body[i];
 			if ( method.start > c ) code.remove( c, method.start );
 
-			method.minify( code );
+			method.minify( code, chars );
 
 			c = method.end;
 		}

--- a/src/program/types/ClassBody.js
+++ b/src/program/types/ClassBody.js
@@ -1,9 +1,9 @@
 import Node from '../Node.js';
 
 export default class ClassBody extends Node {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
 		for ( let i = 0; i < this.body.length; i += 1 ) {
-			this.body[i].attachScope( parent );
+			this.body[i].attachScope( program, parent );
 		}
 	}
 

--- a/src/program/types/ClassDeclaration.js
+++ b/src/program/types/ClassDeclaration.js
@@ -6,10 +6,11 @@ export default class ClassDeclaration extends Class {
 		this.activated = true;
 
 		this.skip = false;
-		super.initialise( program, this.scope );
+		super.initialise( this.program, this.scope );
 	}
 
-	attachScope ( scope ) {
+	attachScope ( program, scope ) {
+		this.program = program;
 		this.scope = scope;
 
 		this.id.declaration = this;
@@ -17,8 +18,8 @@ export default class ClassDeclaration extends Class {
 		this.name = this.id.name; // TODO what is this used for?
 		scope.addDeclaration( this.id, 'class' );
 
-		this.id.attachScope( this.scope );
-		if ( this.superClass ) this.superClass.attachScope( this.scope );
+		this.id.attachScope( program, this.scope );
+		if ( this.superClass ) this.superClass.attachScope( program, this.scope );
 		this.body.attachScope( scope );
 	}
 

--- a/src/program/types/ClassDeclaration.js
+++ b/src/program/types/ClassDeclaration.js
@@ -20,7 +20,7 @@ export default class ClassDeclaration extends Class {
 
 		this.id.attachScope( program, this.scope );
 		if ( this.superClass ) this.superClass.attachScope( program, this.scope );
-		this.body.attachScope( scope );
+		this.body.attachScope( program, scope );
 	}
 
 	initialise ( program, scope ) {

--- a/src/program/types/ClassDeclaration.js
+++ b/src/program/types/ClassDeclaration.js
@@ -6,7 +6,7 @@ export default class ClassDeclaration extends Class {
 		this.activated = true;
 
 		this.skip = false;
-		super.initialise( this.scope );
+		super.initialise( program, this.scope );
 	}
 
 	attachScope ( scope ) {
@@ -22,11 +22,11 @@ export default class ClassDeclaration extends Class {
 		this.body.attachScope( scope );
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( scope.parent ) {
 			// noop — we wait for this declaration to be activated
 		} else {
-			super.initialise( scope );
+			super.initialise( program, scope );
 		}
 	}
 }

--- a/src/program/types/ClassExpression.js
+++ b/src/program/types/ClassExpression.js
@@ -13,7 +13,7 @@ export default class ClassExpression extends Class {
 		this.body.attachScope( this.scope );
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( this.id ) {
 			this.id.declaration = this;
 
@@ -22,7 +22,7 @@ export default class ClassExpression extends Class {
 			this.scope.addReference( this.id );
 		}
 
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 
 	minify ( code ) {

--- a/src/program/types/ClassExpression.js
+++ b/src/program/types/ClassExpression.js
@@ -2,15 +2,15 @@ import Class from './shared/Class.js';
 import Scope from '../Scope.js';
 
 export default class ClassExpression extends Class {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
 		this.scope = new Scope({
 			block: true,
 			parent
 		});
 
-		if ( this.id ) this.id.attachScope( this.scope );
-		if ( this.superClass ) this.superClass.attachScope( this.scope );
-		this.body.attachScope( this.scope );
+		if ( this.id ) this.id.attachScope( program, this.scope );
+		if ( this.superClass ) this.superClass.attachScope( program, this.scope );
+		this.body.attachScope( program, this.scope );
 	}
 
 	initialise ( program, scope ) {

--- a/src/program/types/ClassExpression.js
+++ b/src/program/types/ClassExpression.js
@@ -25,8 +25,8 @@ export default class ClassExpression extends Class {
 		super.initialise( program, scope );
 	}
 
-	minify ( code ) {
-		this.scope.mangle( code );
-		super.minify( code );
+	minify ( code, chars ) {
+		this.scope.mangle( code, chars );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/ConditionalExpression.js
+++ b/src/program/types/ConditionalExpression.js
@@ -31,15 +31,15 @@ export default class ConditionalExpression extends Node {
 		return testValue ? consequentValue : alternateValue;
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		const testValue = this.test.getValue();
 
 		if ( testValue === UNKNOWN ) {
-			super.initialise( scope );
+			super.initialise( program, scope );
 		} else if ( testValue ) {
-			this.consequent.initialise( scope );
+			this.consequent.initialise( program, scope );
 		} else {
-			this.alternate.initialise( scope );
+			this.alternate.initialise( program, scope );
 		}
 	}
 

--- a/src/program/types/ConditionalExpression.js
+++ b/src/program/types/ConditionalExpression.js
@@ -43,7 +43,7 @@ export default class ConditionalExpression extends Node {
 		}
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const testValue = this.test.getValue();
 
 		// TODO rewrite `!a ? b() : c()` as `a ? c() : b()`
@@ -58,18 +58,18 @@ export default class ConditionalExpression extends Node {
 				code.overwrite( this.consequent.end, this.alternate.start, ':' );
 			}
 
-			super.minify( code );
+			super.minify( code, chars );
 		} else if ( testValue ) {
 			// remove test and alternate
 			code.remove( this.start, this.consequent.start );
 			code.remove( this.consequent.end, this.end );
 
-			this.consequent.minify( code );
+			this.consequent.minify( code, chars );
 		} else {
 			// remove test and consequent
 			code.remove( this.start, this.alternate.start );
 
-			this.alternate.minify( code );
+			this.alternate.minify( code, chars );
 		}
 	}
 }

--- a/src/program/types/DoWhileStatement.js
+++ b/src/program/types/DoWhileStatement.js
@@ -1,6 +1,11 @@
 import Node from '../Node.js';
 
 export default class DoWhileStatement extends Node {
+	initialise ( program, scope ) {
+		program.addWord( 'dowhile' );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		// special case
 		if ( this.body.isEmpty() ) {

--- a/src/program/types/DoWhileStatement.js
+++ b/src/program/types/DoWhileStatement.js
@@ -1,7 +1,7 @@
 import Node from '../Node.js';
 
 export default class DoWhileStatement extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		// special case
 		if ( this.body.isEmpty() ) {
 			code.overwrite( this.start + 2, this.test.start, ';while(' );
@@ -20,7 +20,7 @@ export default class DoWhileStatement extends Node {
 				code.overwrite( c, this.test.start, '}while(' );
 			}
 
-			this.body.minify( code );
+			this.body.minify( code, chars );
 		}
 
 		if ( this.end > this.test.end + 1 ) {
@@ -29,6 +29,6 @@ export default class DoWhileStatement extends Node {
 			code.overwrite( this.test.end, c, ')' );
 		}
 
-		this.test.minify( code );
+		this.test.minify( code, chars );
 	}
 }

--- a/src/program/types/EmptyStatement.js
+++ b/src/program/types/EmptyStatement.js
@@ -1,7 +1,7 @@
 import Node from '../Node.js';
 
 export default class EmptyStatement extends Node {
-	initialise () {
+	initialise ( program ) {
 		// noop. this prevents Node#initialise from
 		// 'de-skipping' this node
 	}

--- a/src/program/types/ExpressionStatement.js
+++ b/src/program/types/ExpressionStatement.js
@@ -18,12 +18,12 @@ export default class ExpressionStatement extends Node {
 		return this.expression.getRightHandSide();
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( this.expression.type === 'Literal' || this.expression.getValue() !== UNKNOWN ) {
 			// remove side-effect-free statements (TODO others, not just literals)...
 			return;
 		}
 
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 }

--- a/src/program/types/ForStatement.js
+++ b/src/program/types/ForStatement.js
@@ -9,7 +9,7 @@ export default class ForStatement extends LoopStatement {
 		return this.init && this.init.type === 'VariableDeclaration';
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start + 3;
 
 		let replacement = '(';
@@ -20,7 +20,7 @@ export default class ForStatement extends LoopStatement {
 					code.overwrite( c, statement.start, replacement );
 				}
 
-				statement.minify( code );
+				statement.minify( code, chars );
 
 				c = statement.end;
 				replacement = '';
@@ -33,6 +33,6 @@ export default class ForStatement extends LoopStatement {
 			code.overwrite( c, this.body.start, replacement );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/FunctionDeclaration.js
+++ b/src/program/types/FunctionDeclaration.js
@@ -1,17 +1,17 @@
 import FunctionNode from './shared/FunctionNode.js';
 
 export default class FunctionDeclaration extends FunctionNode {
-	activate ( program ) {
+	activate () {
 		if ( this.activated ) return;
 		this.activated = true;
 
 		this.skip = false;
 
-		if ( this.id ) this.id.initialise( program, this.scope.parent );
+		if ( this.id ) this.id.initialise( this.program, this.scope.parent );
 		this.params.forEach( param => {
-			param.initialise( program, this.scope );
+			param.initialise( this.program, this.scope );
 		});
-		this.body.initialise( program, this.scope );
+		this.body.initialise( this.program, this.scope );
 	}
 
 	initialise ( program, scope ) {

--- a/src/program/types/FunctionDeclaration.js
+++ b/src/program/types/FunctionDeclaration.js
@@ -1,24 +1,24 @@
 import FunctionNode from './shared/FunctionNode.js';
 
 export default class FunctionDeclaration extends FunctionNode {
-	activate () {
+	activate ( program ) {
 		if ( this.activated ) return;
 		this.activated = true;
 
 		this.skip = false;
 
-		if ( this.id ) this.id.initialise( this.scope.parent );
+		if ( this.id ) this.id.initialise( program, this.scope.parent );
 		this.params.forEach( param => {
-			param.initialise( this.scope );
+			param.initialise( program, this.scope );
 		});
-		this.body.initialise( this.scope );
+		this.body.initialise( program, this.scope );
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( scope.parent ) {
 			// noop — we wait for this declaration to be activated
 		} else {
-			this.activate();
+			this.activate( program );
 		}
 	}
 }

--- a/src/program/types/FunctionDeclaration.js
+++ b/src/program/types/FunctionDeclaration.js
@@ -7,6 +7,7 @@ export default class FunctionDeclaration extends FunctionNode {
 
 		this.skip = false;
 
+		this.program.addWord( 'function' );
 		if ( this.id ) this.id.initialise( this.program, this.scope.parent );
 		this.params.forEach( param => {
 			param.initialise( this.program, this.scope );

--- a/src/program/types/FunctionExpression.js
+++ b/src/program/types/FunctionExpression.js
@@ -6,6 +6,7 @@ export default class FunctionExpression extends FunctionNode {
 	}
 
 	initialise ( program ) {
+		program.addWord( 'function' );
 		super.initialise( program, this.scope );
 	}
 }

--- a/src/program/types/FunctionExpression.js
+++ b/src/program/types/FunctionExpression.js
@@ -5,7 +5,7 @@ export default class FunctionExpression extends FunctionNode {
 		return 0;
 	}
 
-	initialise () {
-		super.initialise( this.scope );
+	initialise ( program ) {
+		super.initialise( program, this.scope );
 	}
 }

--- a/src/program/types/FunctionExpression.js
+++ b/src/program/types/FunctionExpression.js
@@ -6,7 +6,7 @@ export default class FunctionExpression extends FunctionNode {
 	}
 
 	initialise ( program ) {
-		program.addWord( 'function' );
+		program.addWord( 'function' ); // TODO only if has function keyword
 		super.initialise( program, this.scope );
 	}
 }

--- a/src/program/types/Identifier.js
+++ b/src/program/types/Identifier.js
@@ -62,7 +62,7 @@ export default class Identifier extends Node {
 		return true;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const value = this.getValue();
 		if ( value !== UNKNOWN && this.isReference() ) {
 			code.overwrite( this.start, this.end, stringify( value ) );

--- a/src/program/types/Identifier.js
+++ b/src/program/types/Identifier.js
@@ -12,7 +12,7 @@ export default class Identifier extends Node {
 		// didn't have a declaration... parameters?
 	}
 
-	attachScope ( scope ) {
+	attachScope ( program, scope ) {
 		this.scope = scope;
 	}
 

--- a/src/program/types/Identifier.js
+++ b/src/program/types/Identifier.js
@@ -32,7 +32,7 @@ export default class Identifier extends Node {
 		return UNKNOWN;
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		// special case
 		if ( ( this.parent.type === 'FunctionExpression' || this.parent.type === 'ClassExpression' ) && this === this.parent.id ) {
 			return;

--- a/src/program/types/Identifier.js
+++ b/src/program/types/Identifier.js
@@ -38,6 +38,8 @@ export default class Identifier extends Node {
 			return;
 		}
 
+		// TODO add global/top-level identifiers to frequency count
+
 		if ( this.isReference() ) {
 			scope.addReference( this );
 		}

--- a/src/program/types/IfStatement.js
+++ b/src/program/types/IfStatement.js
@@ -54,6 +54,8 @@ export default class IfStatement extends Node {
 	}
 
 	initialise ( program, scope ) {
+		// TODO add 'if/else' to character frequency, but only if not rewriting as sequence
+
 		this.skip = false; // TODO skip if known to be safe
 
 		const testValue = this.test.getValue();

--- a/src/program/types/IfStatement.js
+++ b/src/program/types/IfStatement.js
@@ -92,7 +92,7 @@ export default class IfStatement extends Node {
 		this.inverted = this.test.type === 'UnaryExpression' && this.test.operator === '!';
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const testValue = this.test.getValue();
 
 		if ( testValue !== UNKNOWN ) {
@@ -103,17 +103,17 @@ export default class IfStatement extends Node {
 				}
 
 				code.remove( this.start, this.consequent.start );
-				this.consequent.minify( code );
+				this.consequent.minify( code, chars );
 			} else { // if ( false ) {...}
 				// we know there's an alternate, otherwise we wouldn't be here
-				this.alternate.minify( code );
+				this.alternate.minify( code, chars );
 				code.remove( this.start, this.alternate.start );
 			}
 
 			return;
 		}
 
-		this.test.minify( code );
+		this.test.minify( code, chars );
 
 		// if we're rewriting as &&, test must be higher precedence than 6
 		// to avoid being wrapped in parens. If ternary, 4
@@ -136,7 +136,7 @@ export default class IfStatement extends Node {
 			const canRemoveTest = this.test.type === 'Identifier' || this.test.getValue() !== UNKNOWN; // TODO can this ever happen?
 
 			if ( this.alternate && !this.alternate.isEmpty() ) {
-				this.alternate.minify( code );
+				this.alternate.minify( code, chars );
 
 				if ( this.alternate.type === 'BlockStatement' && this.alternate.body.length === 0 ) {
 					if ( canRemoveTest ) {
@@ -202,7 +202,7 @@ export default class IfStatement extends Node {
 		// special case - empty alternate
 		if ( this.alternate && this.alternate.isEmpty() ) {
 			// don't minify alternate
-			this.consequent.minify( code );
+			this.consequent.minify( code, chars );
 			code.remove( this.consequent.end, this.end );
 
 			if ( this.consequent.canSequentialise() ) {
@@ -224,8 +224,8 @@ export default class IfStatement extends Node {
 			return;
 		}
 
-		this.consequent.minify( code );
-		if ( this.alternate ) this.alternate.minify( code );
+		this.consequent.minify( code, chars );
+		if ( this.alternate ) this.alternate.minify( code, chars );
 
 		if ( this.canSequentialise() ) {
 			if ( this.inverted ) code.remove( this.test.start, this.test.start + 1 );

--- a/src/program/types/IfStatement.js
+++ b/src/program/types/IfStatement.js
@@ -53,20 +53,20 @@ export default class IfStatement extends Node {
 		return this.alternate.getRightHandSide();
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		this.skip = false; // TODO skip if known to be safe
 
 		const testValue = this.test.getValue();
 
 		if ( testValue === UNKNOWN ) {
 			// initialise everything
-			this.test.initialise( scope );
-			this.consequent.initialise( scope );
-			if ( this.alternate ) this.alternate.initialise( scope );
+			this.test.initialise( program, scope );
+			this.consequent.initialise( program, scope );
+			if ( this.alternate ) this.alternate.initialise( program, scope );
 		}
 
 		else if ( testValue ) { // if ( true ) {...}
-			this.consequent.initialise( scope );
+			this.consequent.initialise( program, scope );
 
 			if ( this.alternate && this.alternate.type === 'BlockStatement' ) {
 				this.alternate.scope.varDeclarations.forEach( name => {
@@ -77,7 +77,7 @@ export default class IfStatement extends Node {
 
 		else { // if ( false ) {...}
 			if ( this.alternate ) {
-				this.alternate.initialise( scope );
+				this.alternate.initialise( program, scope );
 			} else {
 				this.skip = true;
 			}

--- a/src/program/types/ImportDeclaration.js
+++ b/src/program/types/ImportDeclaration.js
@@ -1,0 +1,11 @@
+import Node from '../Node.js';
+
+export default class ImportDeclaration extends Node {
+	initialise ( program, scope ) {
+		program.addWord( 'import' );
+		if ( this.specifiers.length ) program.addWord( 'from' );
+		program.addWord( this.source.value );
+
+		super.initialise( program, scope );
+	}
+}

--- a/src/program/types/ImportDefaultSpecifier.js
+++ b/src/program/types/ImportDefaultSpecifier.js
@@ -1,10 +1,10 @@
 import Node from '../Node.js';
 
 export default class ImportDefaultSpecifier extends Node {
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		this.local.declaration = this;
 
 		scope.addDeclaration( this.local, 'import' );
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 }

--- a/src/program/types/ImportSpecifier.js
+++ b/src/program/types/ImportSpecifier.js
@@ -1,10 +1,10 @@
 import Node from '../Node.js';
 
 export default class ImportSpecifier extends Node {
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		this.local.declaration = this;
 
 		scope.addDeclaration( this.local, 'import' );
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 }

--- a/src/program/types/LabeledStatement.js
+++ b/src/program/types/LabeledStatement.js
@@ -3,6 +3,7 @@ import Node from '../Node.js';
 export default class LabeledStatement extends Node {
 	initialise ( program, scope ) {
 		program.addWord( this.label.name );
+		super.initialise( program, scope );
 	}
 
 	minify ( code, chars ) {

--- a/src/program/types/LabeledStatement.js
+++ b/src/program/types/LabeledStatement.js
@@ -1,7 +1,13 @@
 import Node from '../Node.js';
 
 export default class LabeledStatement extends Node {
+	initialise ( program, scope ) {
+		program.addWord( this.label.name );
+	}
+
 	minify ( code, chars ) {
+		// TODO can we mangle labels?
+
 		if ( this.body.start > this.label.end + 1 ) {
 			code.overwrite( this.label.end, this.body.start, ':' );
 		}

--- a/src/program/types/LabeledStatement.js
+++ b/src/program/types/LabeledStatement.js
@@ -1,7 +1,7 @@
 import Node from '../Node.js';
 
 export default class LabeledStatement extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.body.start > this.label.end + 1 ) {
 			code.overwrite( this.label.end, this.body.start, ':' );
 		}
@@ -11,7 +11,7 @@ export default class LabeledStatement extends Node {
 			code.appendLeft( this.body.start, ';' );
 			code.remove( this.body.start, this.body.end );
 		} else {
-			this.body.minify( code );
+			this.body.minify( code, chars );
 		}
 	}
 }

--- a/src/program/types/Literal.js
+++ b/src/program/types/Literal.js
@@ -27,7 +27,7 @@ export default class Literal extends Node {
 		// noop
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.value === true || this.value === false ) {
 			code.overwrite( this.start, this.end, this.value ? '!0' : '!1' );
 		}

--- a/src/program/types/Literal.js
+++ b/src/program/types/Literal.js
@@ -2,7 +2,7 @@ import Node from '../Node.js';
 import stringify from '../../utils/stringify.js';
 
 export default class Literal extends Node {
-	attachScope ( scope ) {
+	attachScope ( program, scope ) {
 		if ( this.value === 'use strict' ) {
 			const block = this.parent.parent;
 			if ( block.type === 'Program' || /Function/.test( block.parent.type ) ) {
@@ -23,7 +23,7 @@ export default class Literal extends Node {
 		return this.value;
 	}
 
-	initialise ( program ) {
+	initialise () {
 		// noop
 	}
 

--- a/src/program/types/Literal.js
+++ b/src/program/types/Literal.js
@@ -23,8 +23,8 @@ export default class Literal extends Node {
 		return this.value;
 	}
 
-	initialise () {
-		// noop
+	initialise ( program ) {
+		program.addWord( stringify( this.value ) );
 	}
 
 	minify ( code, chars ) {

--- a/src/program/types/Literal.js
+++ b/src/program/types/Literal.js
@@ -23,7 +23,7 @@ export default class Literal extends Node {
 		return this.value;
 	}
 
-	initialise () {
+	initialise ( program ) {
 		// noop
 	}
 

--- a/src/program/types/LogicalExpression.js
+++ b/src/program/types/LogicalExpression.js
@@ -47,7 +47,7 @@ export default class LogicalExpression extends Node {
 		}
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const leftValue = this.left.getValue();
 
 		if ( leftValue === UNKNOWN ) {
@@ -55,26 +55,26 @@ export default class LogicalExpression extends Node {
 				code.overwrite( this.left.end, this.right.start, this.operator );
 			}
 
-			super.minify( code );
+			super.minify( code, chars );
 		}
 
 		else if ( leftValue ) {
 			if ( this.operator === '&&' ) {
 				code.remove( this.start, this.right.start );
-				this.right.minify( code );
+				this.right.minify( code, chars );
 			} else {
 				code.remove( this.left.end, this.end );
-				this.left.minify( code );
+				this.left.minify( code, chars );
 			}
 		}
 
 		else {
 			if ( this.operator === '&&' ) {
 				code.remove( this.left.end, this.end );
-				this.left.minify( code );
+				this.left.minify( code, chars );
 			} else {
 				code.remove( this.start, this.right.start );
-				this.right.minify( code );
+				this.right.minify( code, chars );
 			}
 		}
 	}

--- a/src/program/types/MemberExpression.js
+++ b/src/program/types/MemberExpression.js
@@ -49,6 +49,11 @@ export default class MemberExpression extends Node {
 		return this;
 	}
 
+	initialise ( program, scope ) {
+		if ( !this.computed ) program.addWord( this.property.name );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		const value = this.getValue();
 

--- a/src/program/types/MemberExpression.js
+++ b/src/program/types/MemberExpression.js
@@ -1,12 +1,12 @@
 import Node from '../Node.js';
-import reserved from '../../utils/reserved.js';
+import { reservedLookup } from '../../utils/reserved.js';
 import { UNKNOWN } from '../../utils/sentinels.js';
 import stringify from '../../utils/stringify.js';
 import getValuePrecedence from '../../utils/getValuePrecedence.js';
 
 function isValidIdentifier ( str ) {
 	// TODO there's probably a bit more to it than this
-	return !reserved[ str ] && /^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test( str );
+	return !reservedLookup[ str ] && /^[a-zA-Z_$][a-zA-Z_$0-9]*$/.test( str );
 }
 
 function canFold ( node, parent ) {
@@ -49,7 +49,7 @@ export default class MemberExpression extends Node {
 		return this;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const value = this.getValue();
 
 		if ( value !== UNKNOWN && canFold( this, this.parent ) ) {
@@ -81,7 +81,7 @@ export default class MemberExpression extends Node {
 					code.overwrite( this.property.end, this.end, ']' );
 				}
 
-				this.property.minify( code );
+				this.property.minify( code, chars );
 			}
 		}
 
@@ -91,6 +91,6 @@ export default class MemberExpression extends Node {
 			}
 		}
 
-		this.object.minify( code );
+		this.object.minify( code, chars );
 	}
 }

--- a/src/program/types/MethodDefinition.js
+++ b/src/program/types/MethodDefinition.js
@@ -2,8 +2,8 @@ import Node from '../Node.js';
 import minifyPropertyKey from './shared/minifyPropertyKey.js';
 
 export default class MethodDefinition extends Node {
-	minify ( code ) {
-		minifyPropertyKey( code, this, false );
-		this.value.minify( code );
+	minify ( code, chars ) {
+		minifyPropertyKey( code, chars, this, false );
+		this.value.minify( code, chars );
 	}
 }

--- a/src/program/types/MethodDefinition.js
+++ b/src/program/types/MethodDefinition.js
@@ -2,6 +2,11 @@ import Node from '../Node.js';
 import minifyPropertyKey from './shared/minifyPropertyKey.js';
 
 export default class MethodDefinition extends Node {
+	initialise ( program, scope ) {
+		if ( !this.computed ) program.addWord( this.key.name );
+		auper.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		minifyPropertyKey( code, chars, this, false );
 		this.value.minify( code, chars );

--- a/src/program/types/MethodDefinition.js
+++ b/src/program/types/MethodDefinition.js
@@ -4,7 +4,7 @@ import minifyPropertyKey from './shared/minifyPropertyKey.js';
 export default class MethodDefinition extends Node {
 	initialise ( program, scope ) {
 		if ( !this.computed ) program.addWord( this.key.name );
-		auper.initialise( program, scope );
+		super.initialise( program, scope );
 	}
 
 	minify ( code, chars ) {

--- a/src/program/types/NewExpression.js
+++ b/src/program/types/NewExpression.js
@@ -5,6 +5,11 @@ export default class NewExpression extends Node {
 		return this.arguments.length > 0 ? 19 : 18;
 	}
 
+	initialise ( program, scope ) {
+		program.addWord( 'new' );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		if ( this.arguments.length ) {
 			let lastNode = this.callee;

--- a/src/program/types/NewExpression.js
+++ b/src/program/types/NewExpression.js
@@ -5,7 +5,7 @@ export default class NewExpression extends Node {
 		return this.arguments.length > 0 ? 19 : 18;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.arguments.length ) {
 			let lastNode = this.callee;
 
@@ -23,6 +23,6 @@ export default class NewExpression extends Node {
 			code.remove( this.callee.end, this.end );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/ObjectExpression.js
+++ b/src/program/types/ObjectExpression.js
@@ -7,7 +7,7 @@ export default class ObjectExpression extends Node {
 		return UNKNOWN;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start;
 
 		if ( this.properties.length ) {
@@ -16,8 +16,8 @@ export default class ObjectExpression extends Node {
 
 				if ( p.start > c + 1 ) code.overwrite( c, p.start, i ? ',' : '{' );
 
-				minifyPropertyKey( code, p, true );
-				p.value.minify( code );
+				minifyPropertyKey( code, chars, p, true );
+				p.value.minify( code, chars );
 
 				c = p.end;
 			}

--- a/src/program/types/ObjectPattern.js
+++ b/src/program/types/ObjectPattern.js
@@ -1,12 +1,12 @@
 import Node from '../Node.js';
 
 export default class ObjectPattern extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start + 1;
 		for ( let i = 0; i < this.properties.length; i += 1 ) {
 			// TODO remove unused properties
 			const property = this.properties[i];
-			property.minify( code );
+			property.minify( code, chars );
 
 			if ( property.start > c ) code.overwrite( c, property.start, i ? ',' : '' );
 			c = property.end;

--- a/src/program/types/ParenthesizedExpression.js
+++ b/src/program/types/ParenthesizedExpression.js
@@ -54,7 +54,7 @@ export default class ParenthesizedExpression extends Node {
 		return this.expression.getValue();
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		let start = this.start;
 		let end = this.end;
 		let parent = this.parent;
@@ -86,6 +86,6 @@ export default class ParenthesizedExpression extends Node {
 			expression.prepend( code, '!' ); // could be any unary operator – uglify uses !
 		}
 
-		expression.minify( code );
+		expression.minify( code, chars );
 	}
 }

--- a/src/program/types/ReturnStatement.js
+++ b/src/program/types/ReturnStatement.js
@@ -5,6 +5,11 @@ import stringify from '../../utils/stringify.js';
 const invalidChars = /[a-zA-Z$_0-9/]/;
 
 export default class ReturnStatement extends Node {
+	initialise ( program, scope ) {
+		program.addWord( 'return' );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		if ( !this.argument ) return;
 

--- a/src/program/types/ReturnStatement.js
+++ b/src/program/types/ReturnStatement.js
@@ -5,7 +5,7 @@ import stringify from '../../utils/stringify.js';
 const invalidChars = /[a-zA-Z$_0-9/]/;
 
 export default class ReturnStatement extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( !this.argument ) return;
 
 		const value = this.argument.getValue();
@@ -24,6 +24,6 @@ export default class ReturnStatement extends Node {
 			code.remove( c, this.argument.start );
 		}
 
-		this.argument.minify( code );
+		this.argument.minify( code, chars );
 	}
 }

--- a/src/program/types/SwitchCase.js
+++ b/src/program/types/SwitchCase.js
@@ -1,6 +1,11 @@
 import Node from '../Node.js';
 
 export default class SwitchCase extends Node {
+	initialise ( program, scope ) {
+		program.addWord( this.test ? 'case' : 'default' );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		let c;
 

--- a/src/program/types/SwitchCase.js
+++ b/src/program/types/SwitchCase.js
@@ -1,11 +1,11 @@
 import Node from '../Node.js';
 
 export default class SwitchCase extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c;
 
 		if ( this.test ) {
-			this.test.minify( code );
+			this.test.minify( code, chars );
 
 			if ( this.test.start > this.start + 5 ) {
 				code.remove( this.start + 5, this.test.start );
@@ -18,7 +18,7 @@ export default class SwitchCase extends Node {
 		}
 
 		this.consequent.forEach( ( statement, i ) => {
-			statement.minify( code );
+			statement.minify( code, chars );
 
 			const separator = i ? ';' : ':'; // TODO can consequents be written as sequences?
 

--- a/src/program/types/SwitchStatement.js
+++ b/src/program/types/SwitchStatement.js
@@ -2,8 +2,8 @@ import Node from '../Node.js';
 import { UNKNOWN } from '../../utils/sentinels.js';
 
 export default class SwitchStatement extends Node {
-	initialise ( scope ) {
-		super.initialise( scope );
+	initialise ( program, scope ) {
+		super.initialise( program, scope );
 
 		if ( this.cases.length === 0 ) {
 			const value = this.discriminant.getValue();

--- a/src/program/types/SwitchStatement.js
+++ b/src/program/types/SwitchStatement.js
@@ -9,6 +9,10 @@ export default class SwitchStatement extends Node {
 			const value = this.discriminant.getValue();
 			this.skip = value !== UNKNOWN || this.discriminant.type === 'Identifier';
 		}
+
+		if ( !this.skip ) {
+			program.addWord( 'switch' );
+		}
 	}
 
 	minify ( code, chars ) {

--- a/src/program/types/SwitchStatement.js
+++ b/src/program/types/SwitchStatement.js
@@ -11,10 +11,10 @@ export default class SwitchStatement extends Node {
 		}
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		// special (and unlikely!) case — no cases, but a non-removable discriminant
 		if ( this.cases.length === 0 ) {
-			this.discriminant.minify( code );
+			this.discriminant.minify( code, chars );
 			code.remove( this.start, this.discriminant.start );
 			code.remove( this.discriminant.end, this.end );
 		}
@@ -37,7 +37,7 @@ export default class SwitchStatement extends Node {
 
 			if ( this.end > c + 1 ) code.overwrite( c, this.end, '}' );
 
-			super.minify( code );
+			super.minify( code, chars );
 		}
 	}
 }

--- a/src/program/types/TaggedTemplateExpression.js
+++ b/src/program/types/TaggedTemplateExpression.js
@@ -1,8 +1,8 @@
 import Node from '../Node.js';
 
 export default class TaggedTemplateExpression extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.quasi.start > this.tag.end ) code.remove( this.tag.end, this.quasi.start );
-		this.quasi.minify( code );
+		this.quasi.minify( code, chars );
 	}
 }

--- a/src/program/types/TemplateLiteral.js
+++ b/src/program/types/TemplateLiteral.js
@@ -30,7 +30,7 @@ export default class TemplateLiteral extends Node {
 		return result;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.parent.type !== 'TaggedTemplateExpression' ) {
 			const value = this.getValue();
 
@@ -49,7 +49,7 @@ export default class TemplateLiteral extends Node {
 
 			const value = expression.getValue();
 			if ( typeof value === 'object' ) { // includes both UNKNOWN and known non-primitives
-				expression.minify( code );
+				expression.minify( code, chars );
 
 				if ( expression.start > quasi.end + 2 ) {
 					code.remove( quasi.end + 2, expression.start );

--- a/src/program/types/TryStatement.js
+++ b/src/program/types/TryStatement.js
@@ -1,6 +1,13 @@
 import Node from '../Node.js';
 
 export default class TryStatement extends Node {
+	initialise ( program, scope ) {
+		program.addWord( 'try' );
+		if ( this.finalizer ) program.addWord( 'finally' );
+
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		if ( this.block.start > this.start + 3 ) code.remove( this.start + 3, this.block.start );
 

--- a/src/program/types/TryStatement.js
+++ b/src/program/types/TryStatement.js
@@ -1,7 +1,7 @@
 import Node from '../Node.js';
 
 export default class TryStatement extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.block.start > this.start + 3 ) code.remove( this.start + 3, this.block.start );
 
 		if ( this.handler ) {
@@ -18,6 +18,6 @@ export default class TryStatement extends Node {
 			}
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/UnaryExpression.js
+++ b/src/program/types/UnaryExpression.js
@@ -26,7 +26,7 @@ export default class UnaryExpression extends Node {
 		return calculators[ this.operator ]( arg );
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		const value = this.getValue();
 		if ( value !== UNKNOWN ) {
 			code.overwrite( this.start, this.end, stringify( value ) );
@@ -41,7 +41,7 @@ export default class UnaryExpression extends Node {
 
 			code.remove( start, this.argument.start );
 
-			super.minify( code );
+			super.minify( code, chars );
 		}
 	}
 }

--- a/src/program/types/UpdateExpression.js
+++ b/src/program/types/UpdateExpression.js
@@ -6,7 +6,7 @@ export default class UpdateExpression extends Node {
 		return this.prefix ? 16 : 17;
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		if ( this.argument.type === 'Identifier' ) {
 			const declaration = scope.findDeclaration( this.argument.name );
 			if ( declaration && declaration.kind === 'const' ) {
@@ -14,6 +14,6 @@ export default class UpdateExpression extends Node {
 			}
 		}
 
-		super.initialise( scope );
+		super.initialise( program, scope );
 	}
 }

--- a/src/program/types/VariableDeclaration.js
+++ b/src/program/types/VariableDeclaration.js
@@ -8,9 +8,9 @@ function compatibleDeclarations ( a, b ) {
 }
 
 export default class VariableDeclaration extends Node {
-	attachScope ( scope ) {
+	attachScope ( program, scope ) {
 		this.declarations.forEach( declarator => {
-			declarator.attachScope( scope );
+			declarator.attachScope( program, scope );
 		});
 
 		scope.functionScope.varDeclarationNodes.push( this );

--- a/src/program/types/VariableDeclaration.js
+++ b/src/program/types/VariableDeclaration.js
@@ -17,6 +17,8 @@ export default class VariableDeclaration extends Node {
 	}
 
 	initialise ( program, scope ) {
+		// TODO `program.addWord(kind)`, but only if this declaration is included...
+
 		let _scope = scope;
 		if ( this.kind === 'var' ) while ( _scope.isBlockScope ) _scope = _scope.parent;
 

--- a/src/program/types/VariableDeclaration.js
+++ b/src/program/types/VariableDeclaration.js
@@ -34,7 +34,7 @@ export default class VariableDeclaration extends Node {
 		});
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.collapsed ) return;
 
 		// collapse consecutive declarations into one
@@ -75,13 +75,13 @@ export default class VariableDeclaration extends Node {
 			if ( declarator.skip ) {
 				if ( !declarator.init || declarator.init.skip ) continue;
 
-				declarator.init.minify( code );
+				declarator.init.minify( code, chars );
 
 				// we have a situation like `var unused = x()` — need to preserve `x()`
 				code.overwrite( c, declarator.init.start, first ? '' : ';' );
 				needsKeyword = true;
 			} else {
-				declarator.minify( code );
+				declarator.minify( code, chars );
 
 				let separator = needsKeyword ?
 					( first ? kind : `;${kind}` ) + ( declarator.id.type === 'Identifier' ? ' ' : '' ) :

--- a/src/program/types/VariableDeclaration.js
+++ b/src/program/types/VariableDeclaration.js
@@ -16,7 +16,7 @@ export default class VariableDeclaration extends Node {
 		scope.functionScope.varDeclarationNodes.push( this );
 	}
 
-	initialise ( scope ) {
+	initialise ( program, scope ) {
 		let _scope = scope;
 		if ( this.kind === 'var' ) while ( _scope.isBlockScope ) _scope = _scope.parent;
 
@@ -27,9 +27,9 @@ export default class VariableDeclaration extends Node {
 		this.declarations.forEach( declarator => {
 			if ( !_scope.parent ) {
 				// only initialise top-level variables. TODO unless we're in e.g. module mode
-				declarator.initialise( scope );
+				declarator.initialise( program, scope );
 			} else {
-				if ( declarator.init ) declarator.init.initialise( scope );
+				if ( declarator.init ) declarator.init.initialise( program, scope );
 			}
 		});
 	}

--- a/src/program/types/VariableDeclarator.js
+++ b/src/program/types/VariableDeclarator.js
@@ -39,11 +39,11 @@ export default class VariableDeclarator extends Node {
 		});
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.init ) {
 			if ( this.init.start > this.id.end + 1 ) code.overwrite( this.id.end, this.init.start, '=' );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/VariableDeclarator.js
+++ b/src/program/types/VariableDeclarator.js
@@ -8,13 +8,13 @@ function mightHaveSideEffects ( node ) {
 }
 
 export default class VariableDeclarator extends Node {
-	activate () {
+	activate ( program ) {
 		if ( this.activated ) return;
 		this.activated = true;
 
 		this.skip = this.parent.skip = false;
-		this.id.initialise( this.scope );
-		if ( this.init ) this.init.initialise( this.scope );
+		this.id.initialise( program, this.scope );
+		if ( this.init ) this.init.initialise( program, this.scope );
 	}
 
 	attachScope ( scope ) {

--- a/src/program/types/VariableDeclarator.js
+++ b/src/program/types/VariableDeclarator.js
@@ -8,23 +8,25 @@ function mightHaveSideEffects ( node ) {
 }
 
 export default class VariableDeclarator extends Node {
-	activate ( program ) {
+	activate () {
 		if ( this.activated ) return;
 		this.activated = true;
 
 		this.skip = this.parent.skip = false;
-		this.id.initialise( program, this.scope );
-		if ( this.init ) this.init.initialise( program, this.scope );
+		this.id.initialise( this.program, this.scope );
+		if ( this.init ) this.init.initialise( this.program, this.scope );
 	}
 
-	attachScope ( scope ) {
+	attachScope ( program, scope ) {
+		this.program = program;
 		this.scope = scope;
+
 		const kind = this.parent.kind;
 
-		this.id.attachScope( scope );
+		this.id.attachScope( program, scope );
 
 		if ( this.init ) {
-			this.init.attachScope( scope );
+			this.init.attachScope( program, scope );
 
 			if ( mightHaveSideEffects( this.init ) ) {
 				this.parent.skip = false;

--- a/src/program/types/WhileStatement.js
+++ b/src/program/types/WhileStatement.js
@@ -5,6 +5,11 @@ export default class WhileStatement extends Node {
 		return this.body.getRightHandSide();
 	}
 
+	initialise ( program, scope ) {
+		program.addWord( 'while' );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		if ( this.test.start > this.start + 6 ) {
 			code.overwrite( this.start + 5, this.test.start, '(' );

--- a/src/program/types/WhileStatement.js
+++ b/src/program/types/WhileStatement.js
@@ -5,7 +5,7 @@ export default class WhileStatement extends Node {
 		return this.body.getRightHandSide();
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		if ( this.test.start > this.start + 6 ) {
 			code.overwrite( this.start + 5, this.test.start, '(' );
 		}
@@ -20,6 +20,6 @@ export default class WhileStatement extends Node {
 			code.remove( this.body.start, this.body.end );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/YieldExpression.js
+++ b/src/program/types/YieldExpression.js
@@ -4,4 +4,9 @@ export default class YieldExpression extends Node {
 	getPrecedence () {
 		return 2;
 	}
+
+	initialise ( program, scope ) {
+		program.addWord( 'yield' );
+		super.initialise( program, scope );
+	}
 }

--- a/src/program/types/index.js
+++ b/src/program/types/index.js
@@ -17,6 +17,7 @@ import FunctionDeclaration from './FunctionDeclaration.js';
 import FunctionExpression from './FunctionExpression.js';
 import Identifier from './Identifier.js';
 import IfStatement from './IfStatement.js';
+import ImportDeclaration from './ImportDeclaration.js';
 import ImportDefaultSpecifier from './ImportDefaultSpecifier.js';
 import ImportSpecifier from './ImportSpecifier.js';
 import LabeledStatement from './LabeledStatement.js';
@@ -64,6 +65,7 @@ export default {
 	FunctionExpression,
 	Identifier,
 	IfStatement,
+	ImportDeclaration,
 	ImportDefaultSpecifier,
 	ImportSpecifier,
 	LabeledStatement,

--- a/src/program/types/shared/Array.js
+++ b/src/program/types/shared/Array.js
@@ -19,7 +19,7 @@ export default class ArrayExpression extends Node {
 		return values;
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start;
 
 		if ( this.elements.length ) {
@@ -43,6 +43,6 @@ export default class ArrayExpression extends Node {
 			if ( this.end > c + 2 ) code.overwrite( c, this.end, '[]' );
 		}
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/shared/Class.js
+++ b/src/program/types/shared/Class.js
@@ -12,7 +12,7 @@ function shouldParenthesizeSuperclass ( node ) {
 }
 
 export default class Class extends Node {
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start + 5;
 
 		if ( this.id ) {
@@ -36,6 +36,6 @@ export default class Class extends Node {
 
 		if ( this.body.start > c ) code.remove( c, this.body.start );
 
-		super.minify( code );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/shared/Class.js
+++ b/src/program/types/shared/Class.js
@@ -12,6 +12,11 @@ function shouldParenthesizeSuperclass ( node ) {
 }
 
 export default class Class extends Node {
+	initialise ( program, scope ) {
+		program.addWord( 'class' );
+		super.initialise( program, scope );
+	}
+
 	minify ( code, chars ) {
 		let c = this.start + 5;
 

--- a/src/program/types/shared/ForInOfStatement.js
+++ b/src/program/types/shared/ForInOfStatement.js
@@ -9,7 +9,7 @@ export default class ForInOfStatement extends LoopStatement {
 		return this.left.type === 'VariableDeclaration';
 	}
 
-	minify ( code, transforms ) {
+	minify ( code, chars ) {
 		if ( this.left.start > this.start + 4 ) {
 			code.overwrite( this.start + 3, this.left.start, '(' );
 		}
@@ -22,8 +22,8 @@ export default class ForInOfStatement extends LoopStatement {
 			code.overwrite( this.right.end, this.body.start, ')' );
 		}
 
-		this.left.minify( code );
-		this.right.minify( code );
-		super.minify( code, transforms );
+		this.left.minify( code, chars );
+		this.right.minify( code, chars );
+		super.minify( code, chars );
 	}
 }

--- a/src/program/types/shared/FunctionNode.js
+++ b/src/program/types/shared/FunctionNode.js
@@ -60,7 +60,7 @@ export default class FunctionNode extends Node {
 		// noop
 	}
 
-	minify ( code ) {
+	minify ( code, chars ) {
 		let c = this.start;
 
 		if ( hasFunctionKeyword( this, this.parent ) ) {
@@ -92,7 +92,7 @@ export default class FunctionNode extends Node {
 		if ( this.params.length ) {
 			for ( let i = 0; i < this.params.length; i += 1 ) {
 				const param = this.params[i];
-				param.minify( code );
+				param.minify( code, chars );
 
 				if ( param.start > c + 1 ) code.overwrite( c, param.start, i ? ',' : '(' );
 				c = param.end;
@@ -103,6 +103,6 @@ export default class FunctionNode extends Node {
 			code.overwrite( c, this.body.start, `()` );
 		}
 
-		this.body.minify( code );
+		this.body.minify( code, chars );
 	}
 }

--- a/src/program/types/shared/FunctionNode.js
+++ b/src/program/types/shared/FunctionNode.js
@@ -60,6 +60,8 @@ export default class FunctionNode extends Node {
 		// noop
 	}
 
+	// TODO `program.addWord('async')` if necessary
+
 	minify ( code, chars ) {
 		let c = this.start;
 

--- a/src/program/types/shared/FunctionNode.js
+++ b/src/program/types/shared/FunctionNode.js
@@ -25,7 +25,8 @@ function keepId ( node ) {
 }
 
 export default class FunctionNode extends Node {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
+		this.program = program;
 		this.scope = new Scope({
 			block: false,
 			parent
@@ -44,7 +45,7 @@ export default class FunctionNode extends Node {
 		}
 
 		this.params.forEach( param => {
-			param.attachScope( this.scope );
+			param.attachScope( program, this.scope );
 
 			extractNames( param ).forEach( node => {
 				node.declaration = this;
@@ -52,7 +53,7 @@ export default class FunctionNode extends Node {
 			});
 		});
 
-		this.body.attachScope( this.scope );
+		this.body.attachScope( program, this.scope );
 	}
 
 	findVarDeclarations () {

--- a/src/program/types/shared/LoopStatement.js
+++ b/src/program/types/shared/LoopStatement.js
@@ -16,6 +16,10 @@ export default class LoopStatement extends Node {
 	}
 
 	initialise ( program, scope ) {
+		program.addWord( 'for' );
+		if ( this.type === 'ForInStatement' ) program.addWord( 'in' );
+		else if ( this.type === 'ForOfStatement' ) program.addWord( 'of' );
+
 		super.initialise( program, this.scope || scope );
 	}
 

--- a/src/program/types/shared/LoopStatement.js
+++ b/src/program/types/shared/LoopStatement.js
@@ -2,16 +2,16 @@ import Node from '../../Node.js';
 import Scope from '../../Scope.js';
 
 export default class LoopStatement extends Node {
-	attachScope ( parent ) {
+	attachScope ( program, parent ) {
 		if ( this.hasVariableDeclaration() ) {
 			this.scope = new Scope({
 				block: true,
 				parent
 			});
 
-			super.attachScope( this.scope );
+			super.attachScope( program, this.scope );
 		} else {
-			super.attachScope( parent );
+			super.attachScope( program, parent );
 		}
 	}
 

--- a/src/program/types/shared/LoopStatement.js
+++ b/src/program/types/shared/LoopStatement.js
@@ -15,8 +15,8 @@ export default class LoopStatement extends Node {
 		}
 	}
 
-	initialise ( scope ) {
-		super.initialise( this.scope || scope );
+	initialise ( program, scope ) {
+		super.initialise( program, this.scope || scope );
 	}
 
 	minify ( code ) {

--- a/src/program/types/shared/LoopStatement.js
+++ b/src/program/types/shared/LoopStatement.js
@@ -19,15 +19,15 @@ export default class LoopStatement extends Node {
 		super.initialise( program, this.scope || scope );
 	}
 
-	minify ( code ) {
-		if ( this.scope ) this.scope.mangle( code );
+	minify ( code, chars ) {
+		if ( this.scope ) this.scope.mangle( code, chars );
 
 		// special case — empty body
 		if ( this.body.isEmpty() ) {
 			code.appendLeft( this.body.start, ';' );
 			code.remove( this.body.start, this.body.end );
 		} else {
-			this.body.minify( code );
+			this.body.minify( code, chars );
 		}
 	}
 }

--- a/src/program/types/shared/minifyPropertyKey.js
+++ b/src/program/types/shared/minifyPropertyKey.js
@@ -2,7 +2,7 @@ function isAccessor ( property ) {
 	return property.kind === 'get' || property.kind === 'set';
 }
 
-export default function minifyPropertyKey ( code, property, isObject ) {
+export default function minifyPropertyKey ( code, chars, property, isObject ) {
 	if ( property.shorthand ) return;
 
 	const separator = ( isObject && !property.method && !isAccessor( property ) ) ? ':' : '';
@@ -39,5 +39,5 @@ export default function minifyPropertyKey ( code, property, isObject ) {
 		code.remove( property.key.end, property.value.start );
 	}
 
-	property.key.minify( code );
+	property.key.minify( code, chars );
 }

--- a/src/utils/reserved.js
+++ b/src/utils/reserved.js
@@ -1,5 +1,6 @@
-let reserved = Object.create( null );
-'do if in for let new try var case else enum eval null this true void with await break catch class const false super throw while yield delete export import public return static switch typeof default extends finally package private continue debugger function arguments interface protected implements instanceof'.split( ' ' )
-	.forEach( word => reserved[ word ] = true );
+export const reserved = 'do if in for let new try var case else enum eval null this true void with await break catch class const false super throw while yield delete export import public return static switch typeof default extends finally package private continue debugger function arguments interface protected implements instanceof'.split( ' ' );
 
-export default reserved;
+export const reservedLookup = Object.create( null );
+reserved.forEach( word => {
+	reservedLookup[ word ] = true;
+});

--- a/test/samples/arrow-functions.js
+++ b/test/samples/arrow-functions.js
@@ -53,6 +53,6 @@ module.exports = [
 			function foo() {
 				return (a) => a;
 			}`,
-		output: `function foo(){return a=>a}`
+		output: `function foo(){return n=>n}`
 	}
 ];

--- a/test/samples/blocks.js
+++ b/test/samples/blocks.js
@@ -106,6 +106,7 @@ module.exports = [
 	},
 
 	{
+		solo: true,
 		description: 'minifies try-catch',
 		input: `
 			try {

--- a/test/samples/blocks.js
+++ b/test/samples/blocks.js
@@ -106,7 +106,6 @@ module.exports = [
 	},
 
 	{
-		solo: true,
 		description: 'minifies try-catch',
 		input: `
 			try {

--- a/test/samples/blocks.js
+++ b/test/samples/blocks.js
@@ -20,7 +20,7 @@ module.exports = [
 				console.log(a);
 				console.log(b);
 			}`,
-		output: `function foo(a,b){console.log(a);console.log(b)}`
+		output: `function foo(o,g){console.log(o);console.log(g)}`
 	},
 
 	{
@@ -30,7 +30,7 @@ module.exports = [
 				console.log(a);
 				console.log(b);
 			}`,
-		output: `var foo=function(a,b){console.log(a);console.log(b)}`
+		output: `var foo=function(o,g){console.log(o);console.log(g)}`
 	},
 
 	{
@@ -113,7 +113,7 @@ module.exports = [
 			} catch ( a ) {
 				console.error( a );
 			}`,
-		output: `try{foo()}catch(a){console.error(a)}`
+		output: `try{foo()}catch(r){console.error(r)}`
 	},
 
 	{
@@ -137,7 +137,7 @@ module.exports = [
 			} finally {
 				bar();
 			}`,
-		output: `try{foo()}catch(a){console.error(a)}finally{bar()}`
+		output: `try{foo()}catch(r){console.error(r)}finally{bar()}`
 	},
 
 	{

--- a/test/samples/classes.js
+++ b/test/samples/classes.js
@@ -26,7 +26,8 @@ module.exports = [
 					// code goes here
 				}
 			}`,
-		output: `var Foo=class a{bar(){}baz(){}}`
+		// TODO remove class ID if possible
+		output: `var Foo=class n{bar(){}baz(){}}`
 	},
 
 	{
@@ -109,7 +110,7 @@ module.exports = [
 				get  bar  () {}
 				set  bar  (val) {}
 			}`,
-		output: `class Foo{get bar(){}set bar(a){}}`
+		output: `class Foo{get bar(){}set bar(n){}}`
 	},
 
 	{

--- a/test/samples/dead-code-elimination.js
+++ b/test/samples/dead-code-elimination.js
@@ -20,7 +20,7 @@ module.exports = [
 				console.log( 'b' );
 				var x;
 			}`,
-		output: `function foo(){a=42;console.log(a);return;var a}`
+		output: `function foo(){n=42;console.log(n);return;var n}`
 	},
 
 	{
@@ -35,7 +35,7 @@ module.exports = [
 					console.log( 'bar' );
 				}
 			}`,
-		output: `function foo(){a();return;function a(){console.log('bar')}}`
+		output: `function foo(){n();return;function n(){console.log('bar')}}`
 	},
 
 	{
@@ -45,7 +45,7 @@ module.exports = [
 				var a = 1, b = 2, c = 3;
 				console.log( a, b );
 			}`,
-		output: `function foo(){var a=1,b=2;console.log(a,b)}`
+		output: `function foo(){var n=1,o=2;console.log(n,o)}`
 	},
 
 	{
@@ -55,7 +55,7 @@ module.exports = [
 				var a = 1, b = 2, c = 3;
 				console.log( a, c );
 			}`,
-		output: `function foo(){var a=1,b=3;console.log(a,b)}`
+		output: `function foo(){var n=1,o=3;console.log(n,o)}`
 	},
 
 	{
@@ -65,7 +65,7 @@ module.exports = [
 				var a = 1, b = 2, c = 3;
 				console.log( b, c );
 			}`,
-		output: `function foo(){var a=2,b=3;console.log(a,b)}`
+		output: `function foo(){var n=2,o=3;console.log(n,o)}`
 	},
 
 	{

--- a/test/samples/functions.js
+++ b/test/samples/functions.js
@@ -8,13 +8,13 @@ module.exports = [
 	{
 		description: 'removes whitespace inside parens',
 		input: `function foo( a, b , c ){console.log(a,b,c)}`,
-		output: `function foo(a,b,c){console.log(a,b,c)}`
+		output: `function foo(n,o,c){console.log(n,o,c)}`
 	},
 
 	{
 		description: 'removes whitespace from anonymous function expression',
 		input: `call(function ( a, b , c ){console.log(a,b,c)})`,
-		output: `call(function(a,b,c){console.log(a,b,c)})`
+		output: `call(function(n,o,c){console.log(n,o,c)})`
 	},
 
 	{
@@ -67,6 +67,6 @@ module.exports = [
 			};
 
 			a();`,
-		output: `var a=function(b){console.log(a)};a()`
+		output: `var a=function(n){console.log(a)};a()`
 	}
 ];

--- a/test/samples/if.js
+++ b/test/samples/if.js
@@ -238,7 +238,7 @@ module.exports = [
 	{
 		description: 'preserves necessary curlies with else block',
 		input: `if ( foo ) { let answer = 42; console.log( answer ); } else { z() }`,
-		output: `if(foo){let a=42;console.log(a)}else z()`
+		output: `if(foo){let g=42;console.log(g)}else z()`
 	},
 
 	{
@@ -345,7 +345,7 @@ module.exports = [
 			}
 
 			foo( x );`,
-		output: `function foo(a){bar&&baz(a);return a}foo(x)`
+		output: `function foo(n){bar&&baz(n);return n}foo(x)`
 	},
 
 	{
@@ -361,7 +361,7 @@ module.exports = [
 			}
 
 			foo()`,
-		output: `function foo(a,b,c){if(a===b)return null;if(c){var d=c+1;console.log(d)}}foo()`
+		output: `function foo(n,l,u){if(n===l)return null;if(u){var o=u+1;console.log(o)}}foo()`
 	},
 
 	{
@@ -403,7 +403,7 @@ module.exports = [
 					console.log( answer );
 				}
 			}`,
-		output: `function x(){var a=function(){return 42};if(y){var b=a();console.log(b)}}`
+		output: `function x(){var n=function(){return 42};if(y){var t=n();console.log(t)}}`
 	},
 
 	{
@@ -563,7 +563,7 @@ module.exports = [
 					y()
 				}
 			else z()`,
-		output: `if(x)try{x()}catch(a){y()}else z()`
+		output: `if(x)try{x()}catch(c){y()}else z()`
 	},
 
 	{

--- a/test/samples/logical-expressions.js
+++ b/test/samples/logical-expressions.js
@@ -62,7 +62,7 @@ module.exports = [
 	{
 		description: 'does not consider environment-specific methods when folding',
 		input: `var includes = [].includes || function(x) { return this.indexOf(x) !== -1; };`,
-		output: `var includes=[].includes||function(a){return this.indexOf(a)!==-1}`
+		output: `var includes=[].includes||function(n){return this.indexOf(n)!==-1}`
 	},
 
 	{

--- a/test/samples/loops.js
+++ b/test/samples/loops.js
@@ -74,7 +74,7 @@ module.exports = [
 			}
 
 			foo();`,
-		output: `function foo(a){let b=a;while(b--)bar(b);for(;b<a;b+=1)bar(b)}foo()`
+		output: `function foo(f){let i=f;while(i--)bar(i);for(;i<f;i+=1)bar(i)}foo()`
 	},
 
 	{
@@ -124,7 +124,7 @@ module.exports = [
 					console.log(i);
 				}
 			}`,
-		output: `function x(){for(var a=0;a<10;a+=1)console.log(a);for(a=0;a<10;a+=1)console.log(a)}`
+		output: `function x(){for(var o=0;o<10;o+=1)console.log(o);for(o=0;o<10;o+=1)console.log(o)}`
 	},
 
 	{
@@ -166,7 +166,7 @@ module.exports = [
 			for (let x of a) {
 				console.log(x);
 			}`,
-		output: `for(let b of a)console.log(b);for(let b of a)console.log(b)`
+		output: `for(let o of a)console.log(o);for(let o of a)console.log(o)`
 	},
 
 	{
@@ -178,7 +178,7 @@ module.exports = [
 					f(foo);
 				}
 			})();`,
-		output: `(()=>{let a=0;for(;;)f(a)})()`
+		output: `(()=>{let o=0;for(;;)f(o)})()`
 	},
 
 	{
@@ -214,7 +214,7 @@ module.exports = [
 				}
 				result = baz;
 			}`,
-		output: `function foo(){while(bar())var a=1;result=a}`
+		output: `function foo(){while(bar())var i=1;result=i}`
 	},
 
 	{

--- a/test/samples/mangling.js
+++ b/test/samples/mangling.js
@@ -8,13 +8,13 @@ module.exports = [
 	{
 		description: 'mangles variables declared in function',
 		input: `fn=function(){var longname;console.log(longname)}`,
-		output: `fn=function(){var a;console.log(a)}`
+		output: `fn=function(){var n;console.log(n)}`
 	},
 
 	{
 		description: 'mangles function parameters',
 		input: `fn=function(longname){console.log(longname)}`,
-		output: `fn=function(a){console.log(a)}`
+		output: `fn=function(n){console.log(n)}`
 	},
 
 	{
@@ -33,7 +33,7 @@ module.exports = [
 
 			foo();
 			bar();`,
-		output: `function foo(a){console.log(a);return function(a){console.log(a)}}function bar(a){console.log(a)}foo();bar()`
+		output: `function foo(n){console.log(n);return function(n){console.log(n)}}function bar(n){console.log(n)}foo();bar()`
 	},
 
 	{
@@ -45,7 +45,7 @@ module.exports = [
 				};
 			}
 			foo()`,
-		output: `function foo(a){return function(b){return a+b}}foo()`
+		output: `function foo(n){return function(r){return n+r}}foo()`
 	},
 
 	{
@@ -57,7 +57,7 @@ module.exports = [
 				}
 			}
 			foo()`,
-		output: `function foo(){return function a(b){b>0&&a(b-1)}}foo()`
+		output: `function foo(){return function n(t){t>0&&n(t-1)}}foo()`
 	},
 
 	{
@@ -72,7 +72,7 @@ module.exports = [
 
 				foo();
 			}());`,
-		output: `!function(){function a(){b()}function b(){}a()}()`
+		output: `!function(){function n(){c()}function c(){}n()}()`
 	},
 
 	{
@@ -83,7 +83,7 @@ module.exports = [
 			} catch ( err ) {
 				console.error( err )
 			}`,
-		output: `try{foo()}catch(a){console.error(a)}`
+		output: `try{foo()}catch(r){console.error(r)}`
 	},
 
 	{
@@ -94,7 +94,7 @@ module.exports = [
 				function bar ( bar ) {}
 				Foo.prototype.bar = bar;
 			}());`,
-		output: `!function(){function a(){}function b(a){}a.prototype.bar=b}()`
+		output: `!function(){function n(){}function o(n){}n.prototype.bar=o}()`
 	},
 
 	{
@@ -103,7 +103,7 @@ module.exports = [
 			function Foo () {}
 			function bar ( bar ) {}
 			Foo.prototype.bar = bar;`,
-		output: `function Foo(){}function bar(a){}Foo.prototype.bar=bar`
+		output: `function Foo(){}function bar(n){}Foo.prototype.bar=bar`
 	},
 
 	{
@@ -116,6 +116,6 @@ module.exports = [
 
 				console.log( bop );
 			}`,
-		output: `function foo(){var a=3;console.log(a)}`
+		output: `function foo(){var n=3;console.log(n)}`
 	}
 ];

--- a/test/samples/objects.js
+++ b/test/samples/objects.js
@@ -26,7 +26,7 @@ module.exports = [
 
 				console.log( obj );
 			}`,
-		output: `function foo(){var a=1,b={longname:a};console.log(b)}`
+		output: `function foo(){var n=1,o={longname:n};console.log(o)}`
 	},
 
 	{
@@ -68,7 +68,7 @@ module.exports = [
 				get  bar  () {},
 				set  bar  (val) {}
 			}`,
-		output: `obj={get bar(){},set bar(a){}}`
+		output: `obj={get bar(){},set bar(n){}}`
 	},
 
 	{

--- a/test/samples/return.js
+++ b/test/samples/return.js
@@ -23,7 +23,7 @@ module.exports = [
 			function foo( value ) {
 				return ( value == null ) ? '' : '' + value;
 			}`,
-		output: `function foo(a){return a==null?'':''+a}`
+		output: `function foo(n){return n==null?'':''+n}`
 	},
 
 	{

--- a/test/samples/var-declarations.js
+++ b/test/samples/var-declarations.js
@@ -50,7 +50,7 @@ module.exports = [
 				var thing = fn();
 				return thing;
 			};`,
-		output: `var x=function(b){var a=fn();return a}`
+		output: `var x=function(r){var n=fn();return n}`
 	},
 
 	{
@@ -63,7 +63,7 @@ module.exports = [
 				console.log(x);
 				console.log(x);
 			}`,
-		output: `function foo(){var a;console.log(a);console.log(a)}`
+		output: `function foo(){var o;console.log(o);console.log(o)}`
 	},
 
 	{
@@ -78,7 +78,7 @@ module.exports = [
 				console.log(x, y);
 				console.log(x, y);
 			}`,
-		output: `function foo(){var a=1,b;console.log(a,b);console.log(a,b)}`
+		output: `function foo(){var o=1,g;console.log(o,g);console.log(o,g)}`
 	},
 
 	{
@@ -124,7 +124,7 @@ module.exports = [
 				console.log(a, b);
 				console.log(a, b);
 			}`,
-		output: `function foo(){mightHaveSideEffects();var a=x(),b=y();console.log(a,b);console.log(a,b)}`
+		output: `function foo(){mightHaveSideEffects();var o=x(),g=y();console.log(o,g);console.log(o,g)}`
 	},
 
 	{
@@ -137,7 +137,7 @@ module.exports = [
 				console.log(a, b);
 				console.log(a, b);
 			}`,
-		output: `function foo(){var a=x();mightHaveSideEffects();var b=y();console.log(a,b);console.log(a,b)}`
+		output: `function foo(){var o=x();mightHaveSideEffects();var g=y();console.log(o,g);console.log(o,g)}`
 	},
 
 	{
@@ -150,6 +150,6 @@ module.exports = [
 				console.log(a, b);
 				console.log(a, b);
 			}`,
-		output: `function foo(){var a=x(),b=y();mightHaveSideEffects();console.log(a,b);console.log(a,b)}`
+		output: `function foo(){var o=x(),g=y();mightHaveSideEffects();console.log(o,g);console.log(o,g)}`
 	}
 ];


### PR DESCRIPTION
This implements most of #110 — rather than mangling variables as `a`, `b`, `c` etc, the most common characters are used first. This results in slightly better gzip compression. As of this PR, Butternut more consistently generates smaller zipped output than Uglify in mangle-only mode. (Full credit for the idea belongs to Uglify.)

There's a little more we can do, e.g. ~~sorting declarations by number of instances~~, but the hard part is done now.

(Edit: turns out sorting declarations by number of instances makes it *worse*. Man, gzip is a mysterious beast.)