### PR TITLE
don't replace member expressions with void 0

### DIFF
--- a/src/program/types/MemberExpression.js
+++ b/src/program/types/MemberExpression.js
@@ -57,7 +57,7 @@ export default class MemberExpression extends Node {
 	minify ( code, chars ) {
 		const value = this.getValue();
 
-		if ( value !== UNKNOWN && canFold( this, this.parent ) ) {
+		if ( value && value !== UNKNOWN && canFold( this, this.parent ) ) {
 			const str = stringify( value );
 
 			if ( str !== null ) {

--- a/test/samples/constant-folding.js
+++ b/test/samples/constant-folding.js
@@ -25,5 +25,11 @@ module.exports = [
 				Infinity:1
 			};`,
 		output: `obj={undefined:1,Infinity:1}`
+	},
+
+	{
+		description: 'does not call unknown properties of strings',
+		input: `x = "a"[ "b" ]( c ) ? any_value_1 : any_value_2`,
+		output: `x="a".b(c)?any_value_1:any_value_2`
 	}
 ];


### PR DESCRIPTION
fixes #132