### PR TITLE
unused function expressions cannot have side-effects

### DIFF
--- a/src/program/types/VariableDeclarator.js
+++ b/src/program/types/VariableDeclarator.js
@@ -3,7 +3,7 @@ import extractNames from '../extractNames.js';
 
 function mightHaveSideEffects ( node ) {
 	// TODO this can get way more sophisticated
-	if ( node.type === 'Identifier' || node.type === 'Literal' ) return false;
+	if ( node.type === 'Identifier' || node.type === 'Literal' || /FunctionExpression/.test( node.type ) ) return false;
 	return true;
 }
 

--- a/test/samples/var-declarations.js
+++ b/test/samples/var-declarations.js
@@ -151,5 +151,15 @@ module.exports = [
 				console.log(a, b);
 			}`,
 		output: `function foo(){var o=x(),g=y();mightHaveSideEffects();console.log(o,g);console.log(o,g)}`
+	},
+
+	{
+		description: 'don\'t turn unused function expression into an illegal declaration',
+		input: `
+			function any_fn () {
+				var any_value_1 = function(d) {}
+				console.log(1);
+			}`,
+		output: `function any_fn(){console.log(1)}`
 	}
 ];


### PR DESCRIPTION
fixes #134 (though we might still need to remove inits of dead variable declarations regardless, notwithstanding that that's nonsensical code)