### PR TITLE
preserve parens around async destructuring arrow functions (fixes #170)

### DIFF
--- a/src/program/types/ArrowFunctionExpression.js
+++ b/src/program/types/ArrowFunctionExpression.js
@@ -67,9 +67,7 @@ export default class ArrowFunctionExpression extends Node {
 					code.overwrite( this.params[0].end, this.body.start, '=>' );
 				}
 			} else {
-				if ( this.params[0].start > c + 1 ) {
-					code.remove( c + 1, this.params[0].start );
-				}
+				code.overwrite( c, this.params[0].start, '(' );
 
 				if ( this.body.start > this.params[0].end + 3 ) {
 					code.overwrite( this.params[0].end, this.body.start, ')=>' );

--- a/test/samples/arrow-functions.js
+++ b/test/samples/arrow-functions.js
@@ -19,6 +19,12 @@ module.exports = [
 
 	{
 		description: 'preserves parens if single param is not identifier',
+		input: `var x = ([ y ]) => y + 1`,
+		output: `var x=([a])=>a+1`
+	},
+
+	{
+		description: 'removes whitespace around parens with single param that is not identifier',
 		input: `var x = ( [ y ] ) => y + 1`,
 		output: `var x=([a])=>a+1`
 	},
@@ -45,6 +51,18 @@ module.exports = [
 		description: 'async arrow function with multiple params',
 		input: `var x = async ( a, b, c ) => a + b + c`,
 		output: `var x=async(a,b,c)=>a+b+c`
+	},
+
+	{
+		description: 'async arrow function preserves parens if single param is not identifier',
+		input: `var x = async([ y ]) => y + 1`,
+		output: `var x=async([a])=>a+1`
+	},
+
+	{
+		description: 'async arrow function removes whitespace around parens when single params that is not identifier',
+		input: `var x = async ( [ y ] ) => y + 1`,
+		output: `var x=async([a])=>a+1`
 	},
 
 	{


### PR DESCRIPTION
Explanation for this edge case: left parens is part of an arrow function expression unless it is async. Thus instead of comparing `this.params[0].start`, `c` and `this.start` with each other to figure out start/end indices of removal, it makes more sense to overwrite everything between `c` and `this.params[0].start` with `(`.