### PR TITLE
wrap parameterless new expressions with params (fixes #169)

### DIFF
--- a/src/program/types/NewExpression.js
+++ b/src/program/types/NewExpression.js
@@ -24,8 +24,16 @@ export default class NewExpression extends Node {
 			if ( this.end > lastNode.end + 1 ) code.overwrite( lastNode.end, this.end, ')' );
 		}
 
-		else if ( this.end > this.callee.end ) {
-			code.remove( this.callee.end, this.end );
+		else {
+			const isMemberExpr = this.parent.type === 'MemberExpression' && this.parent.object === this;
+			if ( isMemberExpr ) {
+				code.prependLeft( this.start, '(' );
+				code.appendRight( this.end, ')' );
+			}
+
+			if ( this.end > this.callee.end ) {
+				code.remove( this.callee.end, this.end );
+			}
 		}
 
 		super.minify( code, chars );

--- a/test/samples/new.js
+++ b/test/samples/new.js
@@ -19,6 +19,30 @@ module.exports = [
 	},
 
 	{
+		description: 'wraps with parens when new expression without params has member access with dot',
+		input: `new Foo().bar`,
+		output: `(new Foo).bar`
+	},
+
+	{
+		description: 'wraps with parens when new expression without params has member access brackets',
+		input: `new Foo()[bar]`,
+		output: `(new Foo)[bar]`
+	},
+
+	{
+		description: 'wraps with single set of parens when new expression without params has member access but wrapped in parens already',
+		input: `(new Foo()).bar`,
+		output: `(new Foo).bar`
+	},
+
+	{
+		description: 'nested parameterless new expressions with member accesses',
+		input: `x = new new Foo().Bar().quu`,
+		output: `x=(new (new Foo).Bar).quu`
+	},
+
+	{
 		description: 'removes parens from new expression without params',
 		input: `x = new Foo()`,
 		output: `x=new Foo`


### PR DESCRIPTION
I mimicked UglifyJS except for the last test case with wrapped new expressions.

For `new new X().Y().z`

UglifyJS output: `new((new X).Y().z)`  _wrong_
butternut output: `(new (new X).Y).z` _correct_

To test it, use the following: 

```
class X { 
  constructor() { 
    this.z = 1; 
    this.Y = class { 
      constructor() { 
        this.z = 2;
      }
    };
  }
}
```